### PR TITLE
docs(changelog): document Claude PR review gate addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to OwnYourCode will be documented in this file.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+#### Repository Infrastructure
+- **Claude PR Review Gate:** Every PR targeting `main` is now automatically reviewed by Claude against the OwnYourCode standards (P/S/T/X/D rule set across Philosophy, Structure, Tooling, Security, and Documentation), the 4 Protocols, and the universal-audience product mission. The reviewer's system prompt lives in `.github/CLAUDE_REVIEWER.md` and is isolated from the workflow YAML for fast iteration. Reviewer enforces an explicit `VERDICT:` contract (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`) so branch protection can gate merges on the verdict.
+
 ## [2.3.0] - 2026-02-10
 
 ### The "Profiles" Release


### PR DESCRIPTION
## Summary

- Adds an `[Unreleased]` section to `CHANGELOG.md` retroactively documenting the Claude PR review gate that was introduced in PR #5
- PR #5 was the bootstrap commit and couldn't include its own CHANGELOG entry (the action's workflow-validation security guard prevented the workflow from running on a PR that introduces the workflow itself)
- This PR is also the **first real end-to-end test** of the reviewer — the workflow on `main` will run on this PR and produce an actual review

## Why this PR satisfies D2

Per the new D2 rule (CHANGELOG Discipline), every PR must add a CHANGELOG entry describing the user-visible change. The CI gate is a contributor-visible change (every PR now gets reviewed) and deserves to be documented in the standard place.

## Test plan

- [ ] Workflow triggers on this PR
- [ ] Claude posts a top-level review comment with a `VERDICT:` line
- [ ] Claude reviews the CHANGELOG entry against rule D2 itself (meta — the reviewer is now reading the documentation of the reviewer)
- [ ] If Claude flags anything, comments cite rule IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)