### PR TITLE
chore(ci): add CODEOWNERS for security-sensitive .github/** paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Solo-maintainer setup — auto-requests review notifications on security-sensitive paths.
+# Not enforced as merge-blocking; informational ownership signal until co-maintainers are added.
+/.github/ @DanielPodolsky


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` declaring `@DanielPodolsky` as the owner of all `.github/**` paths (workflows, reviewer prompt, CODEOWNERS itself, branch protection config)
- **Notification-only** in the current solo-maintainer setup — branch protection's `require_code_owner_reviews` is intentionally `false` because a solo maintainer cannot approve their own PRs in GitHub. CODEOWNERS still triggers auto-review-request, which is the useful signal.
- Will upgrade to enforced code-owner review when co-maintainers join the project.

## Why this PR matters

Without CODEOWNERS, a future contributor (or a careless AI agent) could open a PR modifying `.github/workflows/claude-review.yml` and merge it after passing the Claude check — but the action's workflow-validation guard SKIPS Claude review on workflow-modifying PRs. That would mean workflow modifications go through with effectively no review. CODEOWNERS auto-routes those PRs to the maintainer for manual eyes.

## Test plan

- [ ] Claude reviews this PR (now under the active branch protection gate)
- [ ] Claude verdict line appears at end of top-level comment
- [ ] No findings against the canonical scope list — `chore(ci)` is a valid combination per D3

🤖 Generated with [Claude Code](https://claude.com/claude-code)