### PR TITLE
feat(ci): add @claude mention responder for interactive PR/issue Q&A

### DIFF
--- a/.github/workflows/claude-tag.yml
+++ b/.github/workflows/claude-tag.yml
@@ -1,0 +1,54 @@
+name: Claude Tag Responder (@claude mentions)
+
+# Responds to @claude mentions in PR/issue comments with full thread + diff context.
+# Complementary to claude-review.yml (auto PR review) — different concern, different prompt.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned, labeled]
+
+concurrency:
+  group: claude-tag-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.comment.id || github.event.review.id || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  respond:
+    name: Claude responds to mention
+    runs-on: ubuntu-latest
+
+    # Only fire when @claude is mentioned. Saves API calls on every comment.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout PR/issue context
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Claude responds
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # No prompt: field — let the action auto-detect tag mode and respond
+          # conversationally to the @claude mention with full context (current diff,
+          # PR/issue description, entire comment thread).
+          # If the user asks for a structured review, Claude can Read .github/CLAUDE_REVIEWER.md
+          # to apply the P/S/T/X/D standards.
+          claude_args: |
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh pr checks:*),Bash(gh issue view:*),Bash(gh issue comment:*),Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment"

--- a/.github/workflows/claude-tag.yml
+++ b/.github/workflows/claude-tag.yml
@@ -11,7 +11,7 @@ on:
   pull_request_review:
     types: [submitted]
   issues:
-    types: [opened, assigned, labeled]
+    types: [opened]
 
 concurrency:
   group: claude-tag-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.comment.id || github.event.review.id || github.run_id }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to OwnYourCode will be documented in this file.
 
 #### Repository Infrastructure
 - **Claude PR Review Gate:** Every PR targeting `main` is now automatically reviewed by Claude against the OwnYourCode standards (P/S/T/X/D rule set across Philosophy, Structure, Tooling, Security, and Documentation), the 4 Protocols, and the universal-audience product mission. The reviewer's system prompt lives in `.github/CLAUDE_REVIEWER.md` and is isolated from the workflow YAML for fast iteration. Reviewer enforces an explicit `VERDICT:` contract (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`) so branch protection can gate merges on the verdict.
+- **`@claude` Tag Responder:** Any write-access user can now mention `@claude` in a PR/issue comment, an inline review comment, or a formal PR review to summon Claude for in-thread Q&A with full context (latest PR diff, full comment thread, PR/issue description). Complementary to the auto-review gate — different concern, different workflow file (`.github/workflows/claude-tag.yml`), no system prompt (uses the action's default conversational tag mode). Tool surface is read-and-comment only (no `Edit`/`Write`/shell-wildcards) and the trigger is gated by the action's built-in write-access check.
 
 ## [2.3.0] - 2026-02-10
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude-tag.yml` — triggers on @claude mentions in PR/issue comments and review comments
- Complementary to the existing auto-review workflow: different triggers, different concerns, separate file for independent evolution
- The `if:` condition pre-filters for the `@claude` trigger phrase so the action only spins up when summoned (cost discipline)
- No `prompt:` field — uses the action's default tag mode, where Claude responds conversationally with full PR/issue context

## Use case

After this lands, the workflow looks like:

1. Open a PR → Claude auto-reviews (existing behavior via `claude-review.yml`)
2. Push fixes addressing feedback
3. Comment `@claude does this address the NIT now?` → Claude reads the full thread + the new diff + replies in-thread with context

## Security model

- Trigger phrase `@claude` only fires for users with **write access** (action default)
- Solo maintainer: only @DanielPodolsky can summon Claude — external commenters using `@claude` get silently ignored
- The `if:` condition is belt-and-suspenders cost discipline: even if a write-access user comments without `@claude`, the action doesn't spin up

## Heads-up on the review of this PR

This PR adds a new workflow file. The action's workflow-validation security guard (which skipped review on PR #5) checks the *currently running* workflow against main, not other workflow files in the PR. Since `claude-review.yml` itself is unchanged here, the review SHOULD run on this PR. If it skips, that's data worth knowing — we'd then need a different bootstrap approach for future workflow additions.

## Test plan

- [ ] `claude-review.yml` triggers on this PR (didn't get skipped by the validation guard)
- [ ] Claude verdict line appears in top-level comment
- [ ] No findings against P/S/T/X/D — workflow-only addition with no impact on slash commands, profiles, scripts, or product UX
- [ ] **After merge:** sandbox-test the tag responder by opening any PR and commenting `@claude hello, what do you see in this PR?` — verify Claude responds with PR context

🤖 Generated with [Claude Code](https://claude.com/claude-code)