### PR TITLE
v2.6.0 — Dashboard Elevated: boot sequence, ⌘K palette, tmux bar, mission track

### DIFF
--- a/.claude/commands/own/init.md
+++ b/.claude/commands/own/init.md
@@ -615,7 +615,7 @@ Update `.claude/ownyourcode-manifest.json` with profile settings:
 
 ```json
 {
-  "version": "2.5.0",
+  "version": "2.6.0",
   "installed_at": "...",
   "profile": {
     "type": "junior",
@@ -639,7 +639,7 @@ Update `.claude/ownyourcode-manifest.json` with profile settings:
 
 ```json
 {
-  "version": "2.5.0",
+  "version": "2.6.0",
   "installed_at": "...",
   "profile": {
     "type": "custom",
@@ -1221,7 +1221,7 @@ window.PROJECT = {
     audience: "[enum: myself | employers | clients | real-users]",
     mission:  "[the PROBLEM statement, in the user's words]",
     generated:"[today YYYY-MM-DD]",
-    version:  "2.5.0",
+    version:  "2.6.0",
   },
   dod: [
     { text: "[one concrete, measurable done-criterion]", done: false },
@@ -1254,7 +1254,7 @@ window.PROJECT = {
 | `meta.audience` | Phase 3 selection → enum: "Yourself"→`myself`, "Employers"→`employers`, "A client"→`clients`, "Real users"→`real-users` |
 | `meta.mission` | Phase 2 problem statement (the *why*, in their words) |
 | `meta.generated` | Today, `YYYY-MM-DD` |
-| `meta.version` | Literal `2.5.0` |
+| `meta.version` | Literal `2.6.0` |
 | `dod[]` | Phase 4 Definition-of-Done items, each `done:false` |
 | `stack[]` | Phase 5 stack + Phase 5.1 MCP-verified versions, as 5-tuples |
 | `phases[]` | Phase 5.5 collaborative roadmap — each `status:"roadmap-only"` with `items:[…]`, NO `spec`/`design`/`tasks` (those come from `/own:feature`) |

--- a/.claude/commands/own/theme.md
+++ b/.claude/commands/own/theme.md
@@ -139,7 +139,8 @@ both `<script>` blocks (the data load + the render logic) — is UNTOUCHABLE.
 **The class contract is the current `<style>` itself.** Read the existing
 `<style>` block in `dashboard.html` to learn the complete set of selectors the
 render JS depends on (`.app`, `.hd`, `.sb`, `.nav`, `.tile`, `.bento`, `.kcard`,
-`.ring`, `.phase-numeral`, `.src`, `.bdg`, `.al-*`, etc.). The regenerated CSS
+`.ring`, `.phase-numeral`, `.src`, `.bdg`, `.al-*`, and the v2.6 additions:
+`.boot`/`.bline`, `.pal`, `.tmx`/`.seg`, `.tnode`/`.track`, `.burn`, `.segbar`, etc.). The regenerated CSS
 MUST style that exact same selector set — same class names, same structural
 roles — only the visual treatment changes per the brief.
 

--- a/.github/CLAUDE_REVIEWER.md
+++ b/.github/CLAUDE_REVIEWER.md
@@ -122,7 +122,7 @@ You are NOT a linter. You are a senior engineer mentoring a junior. This means:
 
 - **Explain the WHY.** Don't just say "missing plan-mode warning." Say: *"S3 violation — commands performing file operations need the plan-mode warning at the top (see `init.md` line 9). Without it, users in plan mode will get surprising behavior: skipped steps, half-finished operations, broken flow. The warning sets expectations and prevents support requests."*
 - **Reference the rule ID** (e.g., `P2`, `S3`, `T1`). The grouped prefix (P=Philosophy, S=Structure, T=Tooling, X=Security, D=Documentation) tells the contributor at a glance what kind of issue this is.
-- **Praise non-trivially good decisions.** If you see something *well-engineered* — a thoughtful profile-aware branch, a clean `.sh`/`.ps1` parity update, a teaching insight that genuinely deepens understanding, evidence-cited claims — call it out by name. Reinforcement shapes future contributions as much as correction does.
+- **Praise non-trivially good decisions.** If you see something *well-engineered* — a thoughtful profile-aware branch, a clean `.sh`/`.ps1` parity update, a teaching insight that genuinely deepens understanding, evidence-cited claims — call it out by name. Reinforcement shapes future contributions as much as correction does. **Hard cap: at most ONE praise comment per review, two sentences maximum.** Praise is a signal, not an essay — name the decision and why it's right, then stop.
 - **Suggest, don't dictate.** "Consider rephrasing this as a question to preserve Socratic Teaching" beats "rephrase as a question." Contributors need judgment, not obedience.
 - **Be direct but never harsh.** The code is wrong, the contributor is not. Critique the artifact, not the person.
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -5,8 +5,11 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
+# Per-action groups so a push (incremental review) can never cancel an
+# in-flight full review of the PR opening — only runs of the same kind
+# supersede each other.
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
+  group: claude-review-${{ github.event.pull_request.number }}-${{ github.event.action }}
   cancel-in-progress: true
 
 jobs:
@@ -21,11 +24,18 @@ jobs:
       issues: write
       id-token: write
 
+    # Cost model: a FULL review (~$0.50-1.50) runs once, when the PR opens
+    # (or is reopened / marked ready). Each push ('synchronize') runs a much
+    # cheaper INCREMENTAL review (~$0.15-0.40): it reads the reviewer's own
+    # previous comments, diffs only the newly pushed commits
+    # (github.event.before..after), and reviews just that. For a fresh
+    # full-PR review on demand, mention @claude on the PR (claude-tag.yml).
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          # full history so incremental reviews can diff arbitrary push ranges
+          fetch-depth: 0
 
       - name: Load reviewer system prompt
         id: load_prompt
@@ -36,11 +46,11 @@ jobs:
             echo PROMPT_EOF
           } >> "$GITHUB_OUTPUT"
 
-      - name: Run Claude review
+      - name: Run Claude review (full — PR opened)
+        if: github.event.action != 'synchronize'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -70,3 +80,55 @@ jobs:
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Read,Glob,Grep"
+            --max-turns 25
+
+      - name: Run Claude review (incremental — new commits only)
+        if: github.event.action == 'synchronize'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR TITLE: ${{ github.event.pull_request.title }}
+            PR AUTHOR: ${{ github.event.pull_request.user.login }}
+            BASE BRANCH: ${{ github.event.pull_request.base.ref }}
+            HEAD BRANCH: ${{ github.event.pull_request.head.ref }}
+            NEWLY PUSHED RANGE: ${{ github.event.before }}..${{ github.event.after }}
+
+            ${{ steps.load_prompt.outputs.SYSTEM_PROMPT }}
+
+            ---
+
+            This is an INCREMENTAL review. You (a previous run of you) already
+            reviewed this PR in full when it opened. Do NOT re-review the whole PR.
+
+            Workflow for this review:
+            1. Read your previous feedback so you don't repeat or contradict it:
+               `gh pr view ${{ github.event.pull_request.number }} --comments` and
+               `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments`
+            2. See ONLY what this push changed:
+               `git diff ${{ github.event.before }}..${{ github.event.after }}`
+               (If that range fails — e.g. after a force-push — fall back to
+               `gh pr diff ${{ github.event.pull_request.number }}` and judge what's
+               new relative to your previous comments.)
+            3. Review ONLY the new diff against the standards. Where it addresses one
+               of your earlier findings, acknowledge that in a single line — don't
+               re-litigate what you already approved.
+            4. Scope exception: if the new commits touch contract- or security-critical
+               files (installers, templates, DASHBOARD_CONTRACT.md, workflows), you may
+               read surrounding context to judge cross-cutting impact.
+            5. Inline comments only for NEW findings. Then ONE short summary comment
+               (a few bullets max — this is a delta review, not a fresh report) via
+               `gh pr comment`, ending with the explicit verdict on its own line:
+               - `VERDICT: APPROVE` — ship it
+               - `VERDICT: REQUEST_CHANGES` — blocks merge, must be fixed
+               - `VERDICT: COMMENT` — observations only, no blocker
+            6. If the new diff is trivial (typo, docs wording, version string), say so
+               in at most two lines and give the verdict.
+
+            Do not submit review text as chat messages — only as GitHub comments.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh api repos/*/pulls/*/comments*),Bash(git diff:*),Bash(git log:*),Read,Glob,Grep"
+            --max-turns 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ All notable changes to OwnYourCode will be documented in this file.
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-06-11
+
+### The "Dashboard Elevated" Release
+
+The Terminal-Futurism shell grows up: the terminal voice becomes *interaction*,
+not just decoration. Same `window.PROJECT` contract as v2.5 — existing projects
+upgrade by replacing `dashboard.html` only; `dashboard-data.js` is untouched.
+
+### Added
+
+- **Boot sequence** — on load, a terminal window (mac traffic-light chrome from
+  the existing status palette) types your live project status
+  (`$ own status --dashboard` → phases, task counts) before the app rises in.
+  Any key or click skips it; `prefers-reduced-motion` bypasses it entirely;
+  `#noboot` in the URL disables it.
+- **Command palette** — `⌘K` / `Ctrl+K` (label adapts per platform) or `/`
+  opens a shell-prompt jump menu over every view; digits `1–9` jump directly
+  and `[` / `]` cycle views.
+- **tmux-style status bar** — a live bottom bar with segments for version,
+  project, active phase, task totals, DoD percent, generation date, and a
+  ticking clock.
+- **Mission track** — the Overview renders the roadmap as a timeline: complete
+  phases filled, the active phase pulsing, roadmap phases hollow; a progress
+  line interpolates through the active phase's task completion. Nodes navigate.
+- **Task burn** — per-phase progress bars on the Overview, derived from the
+  same task data the kanban renders (roadmap-only phases show hollow bars).
+- **Micro-interactions** — pointer-tracking glow borders on tiles, count-up
+  stat numerals, kanban column progress bars, a segmented LED Definition-of-Done
+  bar, marching-ants connectors on the architecture diagram, aurora + radar-sweep
+  atmosphere behind the blueprint grid.
+
+### Fixed
+
+- **Architecture diagram overflow** — the SVG no longer stretches to fill wide
+  tiles (capped + centered), and layout is now content-aware: the label gutter
+  sizes to the longest layer label and node boxes size to their text (JetBrains
+  Mono's fixed metrics make text width computable), scaling down then
+  ellipsizing with full text preserved as a hover tooltip. Long labels like
+  `Project (committed)` and long node names no longer collide.
+
+### Changed
+
+- `tests/dashboard-render.test.js` grows 35 → 48 assertions, covering the
+  mission track, task burn, tmux segments, palette, and LED bar alongside every
+  existing v2.5 contract check (the `window.PROJECT` schema is unchanged).
+- `/own:theme`'s class-contract examples now name the v2.6 selector families
+  (`.boot`, `.pal`, `.tmx`, `.tnode`, `.burn`, `.segbar`).
+
 ## [2.5.0] - 2026-05-30
 
 ### The "Dashboard SDD" Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,411 +1,84 @@
 # Changelog
 
-All notable changes to OwnYourCode will be documented in this file.
-
----
-
-## [Unreleased]
-
-## [2.6.0] - 2026-06-11
-
-### The "Dashboard Elevated" Release
-
-The Terminal-Futurism shell grows up: the terminal voice becomes *interaction*,
-not just decoration. Same `window.PROJECT` contract as v2.5 — existing projects
-upgrade by replacing `dashboard.html` only; `dashboard-data.js` is untouched.
-
-### Added
-
-- **Boot sequence** — on load, a terminal window (mac traffic-light chrome from
-  the existing status palette) types your live project status
-  (`$ own status --dashboard` → phases, task counts) before the app rises in.
-  Any key or click skips it; `prefers-reduced-motion` bypasses it entirely;
-  `#noboot` in the URL disables it.
-- **Command palette** — `⌘K` / `Ctrl+K` (label adapts per platform) or `/`
-  opens a shell-prompt jump menu over every view; digits `1–9` jump directly
-  and `[` / `]` cycle views.
-- **tmux-style status bar** — a live bottom bar with segments for version,
-  project, active phase, task totals, DoD percent, generation date, and a
-  ticking clock.
-- **Mission track** — the Overview renders the roadmap as a timeline: complete
-  phases filled, the active phase pulsing, roadmap phases hollow; a progress
-  line interpolates through the active phase's task completion. Nodes navigate.
-- **Task burn** — per-phase progress bars on the Overview, derived from the
-  same task data the kanban renders (roadmap-only phases show hollow bars).
-- **Micro-interactions** — pointer-tracking glow borders on tiles, count-up
-  stat numerals, kanban column progress bars, a segmented LED Definition-of-Done
-  bar, marching-ants connectors on the architecture diagram, aurora + radar-sweep
-  atmosphere behind the blueprint grid.
-
-### Fixed
-
-- **Architecture diagram overflow** — the SVG no longer stretches to fill wide
-  tiles (capped + centered), and layout is now content-aware: the label gutter
-  sizes to the longest layer label and node boxes size to their text (JetBrains
-  Mono's fixed metrics make text width computable), scaling down then
-  ellipsizing with full text preserved as a hover tooltip. Long labels like
-  `Project (committed)` and long node names no longer collide.
-
-### Changed
-
-- `tests/dashboard-render.test.js` grows 35 → 48 assertions, covering the
-  mission track, task burn, tmux segments, palette, and LED bar alongside every
-  existing v2.5 contract check (the `window.PROJECT` schema is unchanged).
-- `/own:theme`'s class-contract examples now name the v2.6 selector families
-  (`.boot`, `.pal`, `.tmx`, `.tnode`, `.burn`, `.segbar`).
-
-## [2.5.0] - 2026-05-30
-
-### The "Dashboard SDD" Release
-
-OwnYourCode's spec-driven development workflow moves from a folder of Markdown
-files to a single, live, app-like dashboard you open in your browser.
-
-### Added
-
-#### Dashboard SDD — Spec-Driven Development becomes a live dashboard
-
-Spec-Driven Development no longer produces a folder of Markdown files. Your whole
-project — mission, stack, roadmap, and every phase's spec / design / tasks — now
-lives in a single **dashboard** you open in your browser. Two files replace all
-the per-page documents:
-
-- `ownyourcode/dashboard/dashboard.html` — a stable view shell (layout + styling + render
-  logic) that you never hand-edit for content.
-- `ownyourcode/dashboard/dashboard-data.js` — `window.PROJECT`, the single source of truth
-  every `/own:*` command reads and writes.
-
-The shell loads its data via `<script src>` (which works under the `file://`
-protocol where `fetch()` is CORS-blocked), so the dashboard is a **double-click
-artifact — no local server**, while still loading web fonts from the network.
-
-- **`DASHBOARD_CONTRACT.md`** (ships into every project): the schema authority
-  for `window.PROJECT` — field semantics, per-command mutation rules, the phase
-  lifecycle (`roadmap-only → specced → complete`), and the safety invariants
-  (`node --check` after every write; exact-string `Edit` by unique task `id`;
-  the shell is never edited for content).
-- **The whole workflow is dashboard-native:**
-  - `/own:init` fills `dashboard-data.js` from the (unchanged) Q&A flow.
-  - `/own:feature` detects the next `roadmap-only` phase and writes its `spec`,
-    `design`, and `tasks` into the phase object, advancing it to `specced`.
-  - `/own:done` flips a task's `done` by unique `id`, propagates satisfied
-    Definition-of-Done items, and completes a phase when all its tasks are done.
-  - `/own:status` reads `window.PROJECT` for all progress (read-only).
-  - `/own:guide` reads the active phase's tasks from the dashboard.
-  Every mutating command validates with `node --check` and uses exact-string
-  `Edit` (never a full-file rewrite).
-- **The dashboard itself** renders the entire project as an app-like cockpit:
-  header + sidebar + per-phase **Spec / Design / Tasks** tabs, a hand-rolled SVG
-  architecture diagram (no library — redraws from data), and a kanban board with
-  a live progress ring. Stack rows carry source attribution
-  (`package.json` / `mcp:DATE` / `verify:URL` / `manual`); component breakdowns
-  include `new`/`modified` badges and file paths.
-- **Default theme — "Terminal-Futurism":** a 1:1 capture of
-  [ownyourcode.dev](https://www.ownyourcode.dev)'s design system — dark
-  near-black surfaces, a terminal-green accent with glow, `Outfit` + `JetBrains
-  Mono`, and a signature "ghost numeral" motif. Dark-native; motion gated by
-  `prefers-reduced-motion`. Ships inline in `dashboard.html` (self-styled).
-- **`/own:theme` is the styling engine:** detects `frontend-design` via the
-  session skill list (not the unreliable filesystem cache), reads a design brief
-  (`.theme/theme-prompt.md`), and regenerates **only** the dashboard's inline
-  `<style>` + font `<link>` — backup-first, with a post-write integrity check
-  that auto-restores if the render contract is damaged. Never touches your data.
-- **Install seeds the dashboard:** `project-install.sh` / `.ps1` provision
-  `dashboard.html` + `dashboard-data.js` + `DASHBOARD_CONTRACT.md` + the theme
-  brief, and retire the old `product/` placeholders. Fallback-first: a missing
-  source template warns and skips rather than seeding a broken project.
-- **Regression suite** (`tests/`, dev-only — never shipped to user projects):
-  install + headless render + static command-contract layers (run via
-  `bash tests/run.sh`), plus a manual fresh-install walkthrough.
-
-> Supersedes an earlier per-page HTML approach (explored after the 2.3.0 release,
-> never tagged) — that work was folded into this single-dashboard model. Existing
-> Markdown projects are unaffected until re-initialized.
+## 2.6.0
 
-#### Repository Infrastructure
-- **Claude PR Review Gate:** Every PR targeting `main` is now automatically reviewed by Claude against the OwnYourCode standards (P/S/T/X/D rule set across Philosophy, Structure, Tooling, Security, and Documentation), the 4 Protocols, and the universal-audience product mission. The reviewer's system prompt lives in `.github/CLAUDE_REVIEWER.md` and is isolated from the workflow YAML for fast iteration. Reviewer enforces an explicit `VERDICT:` contract (`APPROVE` / `REQUEST_CHANGES` / `COMMENT`) so branch protection can gate merges on the verdict.
-- **`@claude` Tag Responder:** Any write-access user can now mention `@claude` in a PR/issue comment, an inline review comment, or a formal PR review to summon Claude for in-thread Q&A with full context (latest PR diff, full comment thread, PR/issue description). Complementary to the auto-review gate — different concern, different workflow file (`.github/workflows/claude-tag.yml`), no system prompt (uses the action's default conversational tag mode). Tool surface is read-and-comment only (no `Edit`/`Write`/shell-wildcards) and the trigger is gated by the action's built-in write-access check.
+- Added a boot sequence — a terminal window types your live project status (phases, task counts) on load; any key skips it, `prefers-reduced-motion` bypasses it, `#noboot` disables it
+- Added a command palette (`⌘K`/`Ctrl+K` with platform-aware label, or `/`) for jumping between views; digits `1–9` jump directly and `[` `]` cycle
+- Added a tmux-style status bar with live segments: version, project, active phase, task totals, DoD percent, and a ticking clock
+- Added a mission track to the Overview — the roadmap as a timeline with complete, active (pulsing), and roadmap-only nodes; clicking a node navigates to its phase
+- Added per-phase task-burn progress bars to the Overview, derived from the same task data the kanban renders
+- Added micro-interactions: pointer-tracking tile glow, count-up stats, kanban column progress bars, a segmented Definition-of-Done bar, marching-ants diagram connectors, and aurora/radar-sweep atmosphere
+- Fixed the architecture diagram stretching to fill wide tiles and text overflowing its boxes — layout is now content-aware (label gutter and node boxes size to their text via JetBrains Mono's fixed metrics), with clipped text preserved as a hover tooltip
+- Fixed Windows PowerShell 5.1 failing to parse the installers when run from disk — all `.ps1` scripts are now pure ASCII (the same convention Chocolatey and Scoop installers use)
+- Expanded the render test from 35 to 48 assertions and added drift guards: every shipped command must be documented in `CLAUDE.md.template`, and every `.ps1` must stay pure ASCII
+- Existing projects upgrade by replacing `dashboard.html` only — the `window.PROJECT` contract is unchanged and `dashboard-data.js` is untouched
 
-## [2.3.0] - 2026-02-10
+## 2.5.0
 
-### The "Profiles" Release
+- Spec-Driven Development now lives in a single browser dashboard instead of a folder of Markdown files: `dashboard.html` (stable view shell, never hand-edited for content) plus `dashboard-data.js` (`window.PROJECT`, the single source of truth every `/own:*` command reads and writes)
+- The dashboard is a double-click `file://` artifact — data loads via `<script src>`, no local server needed
+- Added `DASHBOARD_CONTRACT.md`, shipped into every project: the schema authority for `window.PROJECT`, per-command mutation rules, the phase lifecycle, and safety invariants
+- Made the whole workflow dashboard-native: `/own:init` fills the data file, `/own:feature` specs the next roadmap phase, `/own:done` completes tasks by unique id and propagates Definition-of-Done items, `/own:status` and `/own:guide` read it
+- Added the "Terminal-Futurism" default theme — a 1:1 capture of ownyourcode.dev's design system: dark near-black surfaces, terminal-green accent with glow, Outfit + JetBrains Mono, and the signature ghost-numeral motif
+- `/own:theme` regenerates only the dashboard's inline `<style>` and font links from a design brief — backup-first, with a post-write integrity check that auto-restores if the render contract is damaged
+- Installers now seed the dashboard files and retire the old `product/` placeholders, warning and skipping instead of seeding a broken project when templates are missing
+- Added a dev-only regression suite (`bash tests/run.sh`): install, headless render, and static command-contract layers
+- Every PR to `main` is now auto-reviewed by Claude against the OwnYourCode standards (`.github/CLAUDE_REVIEWER.md`) with an explicit verdict contract for branch protection
+- Mentioning `@claude` in a PR or issue comment now summons in-thread Q&A with full PR context
 
-OwnYourCode now adapts its pedagogy based on who you are. The 6 Gates, code reviews, and quality standards remain the same—but HOW we teach changes based on your profile.
+## 2.3.0
 
-### Added
+- Added 4 developer profiles (Junior, Career Switcher, Interview Prep, Experienced) — the gates and quality standards stay the same, how we teach adapts to who you are
+- Added profile selection to `/own:init`, with settings for career focus, design involvement, analogies, and coding background
+- Juniors now get mandatory design involvement and momentum-driven Socratic questioning grounded in MCP research
+- Experienced developers get efficiency mode, workflow preferences, and an ownership gate that asks "right approach?" instead of "can you explain?"
+- The manifest gained a `profile` section; `CLAUDE.md.template`, `/own:done`, `/own:feature`, and `/own:status` are now profile-aware
 
-#### Profile System
-- **4 Developer Profiles:** Junior, Career Switcher, Interview Prep, Experienced
-- **Profile Selection:** Part of `/own:init` flow—choose your profile before project setup
-- **Profile Templates:** `profiles/*.md` define behavior for each profile type
+## 2.2.5
 
-#### Profile Settings
-- **Career Focus:** `full-extraction` (STAR stories + resume bullets), `tips-only` (insights during teaching), `none` (pure learning)
-- **Design Involvement:** Collaborative spec creation vs. AI generates / developer reviews
-- **Analogies:** Optional domain-specific analogies (e.g., "explain like cooking", "use Star Wars references")
-- **Background:** For juniors—brand new vs. has coded before
+- Fixed `/own:init` using outdated internal knowledge for package versions — versions are now fetched in real time via MCP
+- Fixed `/own:init` creating duplicate `ownyourcode/` directories when run from a project subdirectory
 
-#### Junior Profile Enhancements
-- **Mandatory Design Involvement:** Juniors MUST participate in creating mission.md, stack.md, roadmap.md, spec.md, design.md, tasks.md
-- **Collaborative Thinking Flow:** AI asks concrete technology questions, junior thinks through trade-offs
-- **Momentum-Driven Socratic Questioning:** Questions build up to create productive struggle
-- **MCP-Grounded Guidance:** Context7 + Octocode inform questions with current best practices
+## 2.2.4
 
-#### Experienced Profile
-- **Efficiency Mode:** Skip fundamentals, peer-level collaboration
-- **Workflow Preferences:** Pair programming, async review, or minimal intervention
-- **Adapted Gates:** Ownership gate focuses on "right approach?" not "can you explain?"
+- Fixed CLAUDE.md duplication when re-running the installer
+- Fixed uninstall leaving OwnYourCode files behind
 
-### Changed
+## 2.2.3
 
-#### Manifest Structure
-- Added `profile` section with `type`, `configured_at`, and `settings`
-- Settings include: `background`, `career_focus`, `design_involvement`, `analogies`, `previous_field`, `target_companies`, `timeline`, `focus_areas`, `workflow_preference`
+- Stack recommendations now show verified versions with source attribution: read from `package.json`, verified via MCP, or flagged "verify at URL"
 
-#### CLAUDE.md.template
-- Added profile injection points for dynamic behavior
-- Role phrasing adapts per profile
-- Career extraction section now profile-aware
+## 2.2.2
 
-#### Commands Updated
-- `/own:init`: Profile selection added at beginning (Phase -1)
-- `/own:done`: Phases 5-6 (career extraction) conditional on `career_focus` setting
-- `/own:feature`: Collaborative vs. standard spec generation based on profile
-- `/own:status`: Career Stats section hidden when `career_focus=none`
+- Added `.claude/agents/` to `.gitignore` for personal agent files
 
-### Philosophy
+## 2.2.1
 
-> "OwnYourCode teaches everyone the same WHAT (6 Gates, quality standards, code reviews).
-> The Profiles system changes HOW we teach based on who you are."
+- Fixed the interactive prompt not appearing when installing via `curl ... | bash` — input now reads from `/dev/tty`
 
----
+## 2.2.0
 
-## [2.2.5] - 2026-02-05
+- Redesigned the README as a focused landing page: "The 4 Protocols" surfaced as visible methodology, universal ownership positioning, new tagline "AI guides, you build. You own the result."
+- Unified all commands under the `/own:` prefix
+- Improved skill descriptions so skills auto-trigger more reliably
+- Fixed Windows installation: PowerShell string escaping, here-string compatibility, and `irm`-based project install
 
-### Fixed
+## 2.1.0
 
-**Version Fetching in /own:init**
-- Added `mcp__octocode__packageSearch` to allowed-tools for real-time npm version fetching
-- Added explicit version fetching protocol with package names table and workflow example
-- Prevents Claude from using outdated internal knowledge for version numbers
+- Learnings now persist globally across all projects at `~/ownyourcode/learning/` — patterns and failures compound across your entire engineering journey
+- `/init` now detects and teaches package managers (npm, pnpm, bun, yarn)
+- Package versions are always verified via Context7 + OctoCode before being recommended
+- Skills now apply silently during `/feature` and `/done` — the junior receives quality guidance without seeing skill names
+- Completed specs auto-archive to `completed/` and task tracking updates in real time
 
-**Directory Location in /own:init**
-- Added "CRITICAL: You Are UPDATING, Not Creating" section
-- Clarifies that `ownyourcode/` already exists from installation (sibling to CLAUDE.md)
-- Prevents creating duplicate `ownyourcode/` directories when running from project subdirectories
+## 2.0.0
 
----
+- Added the 6 Mentorship Gates — mandatory quality checkpoints before completing any task: Ownership (can block), Security, Error Handling, Performance, Fundamentals, Testing
+- Added the Learning Flywheel: `/advise` for pre-work intelligence, `/retrospective` for capturing learnings, and a persistent learning registry with patterns and failures
+- Added 4 fundamental skills (Testing, SEO, Accessibility, Documentation) and 2 commands (`/own:test`, `/own:docs`)
+- Added the Resistance Protocol — enforced pushback when juniors try to shortcut ("just write the code for me" gets redirected to learning)
+- Every completed task now produces STAR interview stories and resume bullets
 
-## [2.2.4] - 2026-02-03
+## 1.0.0
 
-### Fixed
-
-**Installation Scripts**
-- Prevent CLAUDE.md duplication when re-running install
-- Ensure clean uninstall removes all OwnYourCode files properly
-
----
-
-## [2.2.3] - 2026-01-31
-
-### Fixed
-
-**Version Accuracy in /own:init**
-- Stack recommendations now show verified versions with source attribution
-- Existing projects: versions read directly from package.json (source of truth)
-- New projects: versions verified via MCP, or show "Verify at [docs URL]" if unavailable
-- Added Source column to stack.md template (package.json / MCP verified / Verify at URL)
-- Added Version Freshness section to remind users when to re-verify
-- Prevents outdated version numbers (e.g., "React 18+") from appearing in generated docs
-
----
-
-## [2.2.2] - 2026-01-30
-
-### Changed
-
-**Repository Configuration**
-- Added `.claude/agents/` to .gitignore for personal agent files
-
----
-
-## [2.2.1] - 2026-01-30
-
-### Fixed
-
-- **Piped Installation Prompt**: Fixed interactive prompt not appearing when running `curl ... | bash`. Now reads from `/dev/tty` instead of stdin.
-
----
-
-## [2.2.0] - 2026-01-30
-
-### The "Ownership & Polish" Release
-
-Focused on clarity, consistency, and Windows compatibility. The README now sells the methodology, commands are unified, and Windows users can install without issues.
-
-### Changed
-
-#### README Transformation
-- Redesigned as a focused landing page (239 → 148 lines)
-- Surfaced "The 4 Protocols" as visible methodology
-- Removed badge wall and visual clutter
-- Changed positioning from "for Juniors" to universal ownership message
-- New tagline: "AI guides, you build. You own the result."
-
-#### Command Naming Unification
-- All commands now consistently use `/own:` prefix
-- Improved command descriptions for clearer purpose
-- Better onboarding flow in `/own:init`
-
-#### Skill Auto-Invocation
-- Optimized skill descriptions for improved pattern matching
-- Skills now trigger more reliably based on file context
-
-### Fixed
-
-#### Windows Installation
-- Fixed PowerShell string escaping (parentheses → brackets)
-- Fixed here-string compatibility issues
-- Used `irm` for project-install to bypass git encoding problems
-- Windows users can now install without manual intervention
-
----
-
-## [2.1.0] - 2026-01-06
-
-### The "Global Learning + Silent Skills" Release
-
-Quality improvements based on real-world testing. Learnings now persist across projects, skills apply silently, and research is always verified.
-
-### Added
-
-#### Global Learning Registry
-- Learning persists across ALL projects at `~/ownyourcode/learning/`
-- Patterns and failures compound across your entire engineering journey
-- `/advise` queries global registry + MCP research
-- `/retrospective` writes to global registry
-
-#### Package Manager Education
-- `/init` now detects and teaches about npm, pnpm, bun, and yarn
-- Fresh projects ask which package manager to use
-- Existing projects detect from lock files and provide education
-
-#### Version Intelligence
-- Always verify latest package versions via Context7 + OctoCode before recommending
-- Document versions in `stack.md`
-- Warn about outdated dependencies
-
-#### Silent Skill Activation
-- Skills shape specs during `/feature` planning
-- Skills shape code review during `/done`
-- Junior never sees skill names — just receives quality guidance naturally
-
-#### Dual MCP Research Protocol
-- BOTH Context7 AND OctoCode are mandatory for any technical research
-- "According to the React 19 docs [Context7]... Looking at production [OctoCode]..."
-
-### Changed
-
-- Spec archival now automatic — completed specs move to `completed/` after `/done`
-- Task tracking now real-time — tasks marked complete during work, not just at end
-- Learning paths changed from project-local to global (`~/ownyourcode/learning/`)
-- Install scripts updated for v2.1 features
-
-### Technical
-
-- `base-install.sh` creates global learning structure
-- `project-install.sh` no longer creates local learning directories
-- CLAUDE.md.template has 5 new mandatory rules
-- feature.md has internal skill mapping (Phase 2.5)
-- init.md has package manager detection and version verification
-
----
-
-## [2.0.0] - 2026-01-02
-
-### The "Learning Flywheel" Release
-
-Major overhaul transforming OwnYourCode from a strict mentor into a complete learning system that compounds growth over time.
-
-### Added
-
-#### 6 Mentorship Gates
-Mandatory quality checkpoints before completing any task:
-- **Gate 1: Ownership** (CAN BLOCK) - Must explain your own code
-- **Gate 2: Security** (Warnings) - OWASP Top 10 checks
-- **Gate 3: Error Handling** (Warnings) - Graceful failure verification
-- **Gate 4: Performance** (Warnings) - O(n²), N+1 query detection
-- **Gate 5: Fundamentals** (Suggestions) - Code quality polish
-- **Gate 6: Testing** (Warnings) - Encourages testing habit
-
-#### Learning Flywheel
-Your learnings compound across sessions:
-- `/advise` command - Pre-work intelligence from past learnings
-- `/retrospective` command - Capture learnings after each task
-- `learning/LEARNING_REGISTRY.md` - Persistent growth tracker
-- `learning/patterns/` - Reusable solutions discovered
-- `learning/failures/` - Mistakes learned from
-
-#### 4 New Fundamental Skills
-- **Testing** - Testing pyramid, Vitest/Jest guidance, AAA pattern
-- **SEO** - Meta tags, semantic HTML, Open Graph
-- **Accessibility** - WCAG basics, keyboard navigation, ARIA
-- **Documentation** - WHY not WHAT, README structure, JSDoc
-
-#### 2 New Commands
-- `/own:test` - Guide through writing tests (junior writes, AI guides)
-- `/own:docs` - Guide through writing documentation
-
-#### Resistance Protocol
-Enforced pushback when juniors try to shortcut:
-- "Just write the code for me" → Redirected to learning
-- "This is taking too long" → Refocused on growth
-- "I don't need to explain it" → Required explanation
-
-#### Career Extraction
-Every completed task produces:
-- STAR interview stories (Situation, Task, Action, Result)
-- Resume bullets (Action Verb + What + Impact)
-
-### Changed
-
-- Commands now total 10 (was 8)
-- Fundamental skills now total 11 (was 7)
-- Gates now total 6 (was 5)
-- `/done` command now includes Testing Gate
-- README completely rewritten for v2.0
-
-### Technical
-
-- Skills architecture with auto-invocation based on file patterns
-- Updated install scripts for new skill structure
-
-### MCP Integration
-
-Required for full functionality:
-- **Context7** — Official documentation lookup and citation
-- **Octocode** — GitHub code search for production patterns
-
----
-
-## [1.0.0] - 2025-12-XX
-
-### Initial Release
-
-The original OwnYourCode with:
-- 8 slash commands
-- 7 fundamental skills
-- 5 mentorship gates
-- Anti-Brain-Rot Rules
-- Protocol D debugging
-- STAR story extraction
-
----
-
-## Philosophy
-
-> "If you took away the AI tomorrow, could this junior still code?"
->
-> OwnYourCode makes the answer: **YES**.
-
-The goal is not to ship code. The goal is to build the engineer.
+- Initial release: 8 slash commands, 7 fundamental skills, 5 mentorship gates, Anti-Brain-Rot rules, Protocol D debugging, and STAR story extraction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed the architecture diagram stretching to fill wide tiles and text overflowing its boxes — layout is now content-aware (label gutter and node boxes size to their text via JetBrains Mono's fixed metrics), with clipped text preserved as a hover tooltip
 - Fixed Windows PowerShell 5.1 failing to parse the installers when run from disk — all `.ps1` scripts are now pure ASCII (the same convention Chocolatey and Scoop installers use)
 - Expanded the render test from 35 to 48 assertions and added drift guards: every shipped command must be documented in `CLAUDE.md.template`, and every `.ps1` must stay pure ASCII
+- The PR review gate now runs one full review when a PR opens and cheap incremental reviews (previous comments + newly pushed commits only) on each push, with turn caps and a one-comment praise cap
 - Existing projects upgrade by replacing `dashboard.html` only — the `window.PROJECT` contract is unchanged and `dashboard-data.js` is untouched
 
 ## 2.5.0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <sub>v2.5.0 · MIT License</sub>
+  <sub>v2.6.0 · MIT License</sub>
 </p>
 
 ---

--- a/core/CLAUDE.md.template
+++ b/core/CLAUDE.md.template
@@ -238,6 +238,7 @@ The junior should see tasks being checked off as work progresses, not all at onc
 - `/own:retro` — **Capture learnings** (grows the flywheel)
 - `/own:status` — Check progress + learning stats
 - `/own:profile` — View or change profile settings
+- `/own:theme` — Restyle the dashboard from a design brief (styling only — never content)
 
 ---
 

--- a/core/templates/DASHBOARD_CONTRACT.md
+++ b/core/templates/DASHBOARD_CONTRACT.md
@@ -115,7 +115,7 @@ Task = {
 | `audience` | enum | `"myself"` \| `"employers"` \| `"clients"` \| `"real-users"` | `/own:init` Phase 3 |
 | `mission` | string | The PROBLEM statement (the *why* — not the solution) | `/own:init` Phase 2 |
 | `generated` | string | ISO date `YYYY-MM-DD` | Set on every write that re-stamps |
-| `version` | string | OwnYourCode version that generated/last-modified this file (e.g. `"2.5.0"`) | Source-of-truth: the OwnYourCode release at write time. NOT the user's project version. |
+| `version` | string | OwnYourCode version that generated/last-modified this file (e.g. `"2.6.0"`) | Source-of-truth: the OwnYourCode release at write time. NOT the user's project version. |
 
 ### 3.2 `dod` (Definition of Done items)
 

--- a/core/templates/dashboard-data.js.template
+++ b/core/templates/dashboard-data.js.template
@@ -25,7 +25,7 @@ window.PROJECT = {
     audience: "myself",
     mission: "This dashboard is empty. Run /own:init in Claude Code to define your project's mission, stack, and roadmap — then /own:feature to spec your first phase.",
     generated: "—",
-    version: "2.5.0",
+    version: "2.6.0",
   },
   dod: [],     // Definition-of-Done items: { text, done }
   stack: [],   // 5-tuple rows: [layer, tech, version, source, purpose]

--- a/core/templates/dashboard.html.template
+++ b/core/templates/dashboard.html.template
@@ -549,6 +549,7 @@ function renderArch(d){
      (capped at 30% width), and node boxes size to their text — scaled down
      proportionally on crowded rows, shrinking type (floor 8px) and finally
      ellipsizing. Clipped text keeps its full value as a hover <title>. */
+  if(!d || !Array.isArray(d.layers) || !d.layers.length) return "";
   const W=640, gap=14, bandH=42, vGap=26, minBox=60, maxBox=260;
   const LBL_FS=10, NODE_FS=11, CH=0.62;
   const clip=(t,max)=> t.length>max ? t.slice(0, Math.max(1,max-1))+"…" : t;

--- a/core/templates/dashboard.html.template
+++ b/core/templates/dashboard.html.template
@@ -10,6 +10,15 @@
   not. The /own:* commands rewrite dashboard-data.js, NOT this file, to
   keep the dashboard in sync. Refresh the tab to see updates.
 
+  v2.6 — the terminal voice became interaction, not just decoration:
+    · Boot sequence    — terminal window types the project status on load
+    · ⌘K palette       — command-line navigation (also: / , digits, [ ])
+    · tmux status bar  — live segments: phase, tasks, DoD, clock
+    · Mission track    — phase timeline visualization on Overview
+    · Task burn        — per-phase progress bars derived from tasks
+    · Cursor glow      — tiles carry a pointer-tracking border light
+  All motion honors prefers-reduced-motion. Works on file://.
+
   Authority: ownyourcode/dashboard/DASHBOARD_CONTRACT.md defines the window.PROJECT
   schema this shell renders. Do not hand-edit this file for content —
   only /own:theme (or a deliberate design change) touches the styling.
@@ -21,45 +30,32 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Project Dashboard · OwnYourCode</title>
 
-<!-- Type system: Outfit (display/body sans) + JetBrains Mono (the terminal
-     voice — labels, numbers, IDs, code). Loaded from the network — fine on
-     file:// when online, which is always (OwnYourCode runs through Claude).
-     System fallbacks in the tokens keep the page legible if fonts fail. -->
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
 
 <style>
-  /* ═══ Tokens — Terminal-Futurism (from ownyourcode.dev) ═══ */
+  /* ═══ Tokens — Terminal-Futurism (ownyourcode.dev), elevated ═══ */
   :root {
-    /* Deep-space background ramp (depth via stacked near-blacks) */
-    --bg: #030305;            /* --bg-void   */
-    --canvas: #050508;        /* --bg-deep   */
-    --sidebar: #0a0a0f;       /* --bg-surface*/
-    --tile-2: #0d0d14;        /* --bg-elevated */
-    --tile: #111118;          /* --bg-card   */
-    --subtle: #0d0d14;
+    --bg: #030305;            --canvas: #050508;        --sidebar: #0a0a0f;
+    --tile-2: #0d0d14;        --tile: #111118;          --subtle: #0d0d14;
 
-    /* The green of ownership — the ONE accent */
-    --accent: #22c55e;        --accent-2: #4ade80;     --accent-dim: #16a34a;
+    --accent: #22c55e;        --accent-2: #4ade80;      --accent-dim: #16a34a;
     --accent-soft: rgba(34,197,94,0.10);
     --accent-line: rgba(34,197,94,0.30);
     --accent-glow: rgba(34,197,94,0.40);
+    --accent-grad: linear-gradient(90deg, var(--accent-dim), var(--accent), var(--accent-2));
 
-    /* Text hierarchy (slate ramp) */
-    --text: #f1f5f9;          --text-2: #94a3b8;       --text-3: #64748b;
+    --text: #f1f5f9;          --text-2: #94a3b8;        --text-3: #64748b;
     --text-dim: #475569;
 
-    /* Terminal-window chrome — doubles as the status palette */
-    --dang: #ff5f56;          --warn: #ffbd2e;         --ok: #27c93f;
+    --dang: #ff5f56;          --warn: #ffbd2e;          --ok: #27c93f;
 
-    /* Borders & lines */
     --border: rgba(148,163,184,0.10);
     --border-2: rgba(148,163,184,0.18);
     --hair: rgba(148,163,184,0.07);
     --grid-line: rgba(34,197,94,0.035);
 
-    /* Shadows — dark, with green glow on lift */
     --sh-1: 0 1px 2px rgba(0,0,0,0.5);
     --sh-2: 0 4px 16px rgba(0,0,0,0.55), 0 1px 3px rgba(0,0,0,0.4);
     --sh-3: 0 16px 48px rgba(0,0,0,0.6), 0 4px 12px rgba(0,0,0,0.5);
@@ -68,7 +64,7 @@
     --fs: "Outfit", system-ui, -apple-system, sans-serif;
     --fm: "JetBrains Mono", ui-monospace, Menlo, Consolas, monospace;
     --r: 14px; --r-sm: 9px; --r-pill: 999px;
-    --e: cubic-bezier(0.16,1,0.3,1);      /* ease-out-expo */
+    --e: cubic-bezier(0.16,1,0.3,1);
     --spring: cubic-bezier(0.34,1.56,0.64,1);
   }
 
@@ -77,12 +73,32 @@
   body { margin: 0; font-family: var(--fs); color: var(--text); background: var(--bg);
     -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; line-height: 1.6; font-size: 16px; }
   ::selection { background: var(--accent); color: var(--bg); }
+  button { font: inherit; color: inherit; }
+  kbd { font-family: var(--fm); font-size: 0.66rem; background: var(--tile); border: 1px solid var(--border-2);
+    border-bottom-width: 2px; border-radius: 5px; padding: 0.06rem 0.4rem; color: var(--text-2); }
 
-  /* Fractal-noise grain overlay for depth (from the site) */
+  /* Grain overlay */
   body::after { content:""; position:fixed; inset:0; z-index:9999; pointer-events:none; opacity:0.025;
     background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E"); }
 
-  /* Custom scrollbar (dark) */
+  /* ═══ Atmosphere — aurora blobs drifting behind everything ═══ */
+  .aurora { position: fixed; inset: 0; z-index: 0; pointer-events: none; overflow: hidden; }
+  .aurora i { position: absolute; border-radius: 50%; filter: blur(90px); opacity: 0.08; }
+  .aurora i:nth-child(1) { width: 60vw; height: 60vw; left: -18vw; top: -28vw;
+    background: radial-gradient(circle, var(--accent) 0%, transparent 65%);
+    animation: drift1 26s ease-in-out infinite alternate; }
+  .aurora i:nth-child(2) { width: 44vw; height: 44vw; right: -16vw; bottom: -20vw;
+    background: radial-gradient(circle, var(--accent-dim) 0%, transparent 65%);
+    animation: drift2 32s ease-in-out infinite alternate; }
+  @keyframes drift1 { to { transform: translate(9vw, 7vh) scale(1.12); } }
+  @keyframes drift2 { to { transform: translate(-8vw, -6vh) scale(0.92); } }
+
+  /* Periodic radar sweep — one faint band crossing the screen */
+  .sweep { position: fixed; left: 0; right: 0; top: -160px; height: 140px; z-index: 1; pointer-events: none;
+    background: linear-gradient(180deg, transparent, rgba(34,197,94,0.045) 50%, transparent);
+    animation: sweep 13s linear infinite; }
+  @keyframes sweep { 0%, 62% { transform: translateY(0); } 100% { transform: translateY(calc(100vh + 320px)); } }
+
   ::-webkit-scrollbar { width: 9px; height: 9px; }
   ::-webkit-scrollbar-track { background: var(--canvas); }
   ::-webkit-scrollbar-thumb { background: var(--tile-2); border-radius: 5px; }
@@ -90,260 +106,393 @@
 
   /* Micro-labels ride the mono face — the terminal voice. */
   .eye, .sb-label, .tile .k, .stat .lbl, .bdg, .mini .ei, .kcol h3, thead th,
-  .gst .gl, .dodcard h4, .phase-subtitle { font-family: var(--fm); }
+  .gst .gl, .dodcard h4, .tn-num, .tn-meta, .burn .bl, .burn .bn, .tab, .seg { font-family: var(--fm); }
 
-  /* ═══ App shell ═══ */
-  .app { display: grid; height: 100vh; grid-template-columns: 292px 1fr;
-    grid-template-rows: auto 1fr; grid-template-areas: "header header" "sidebar main"; }
+  /* ═══ Boot sequence — a terminal window types the status, then lifts ═══ */
+  .boot { position: fixed; inset: 0; z-index: 10000; display: flex; align-items: center; justify-content: center;
+    background: var(--bg); transition: opacity .5s var(--e), visibility .5s; }
+  .boot.off { opacity: 0; visibility: hidden; }
+  .boot-win { width: min(580px, 88vw); background: var(--sidebar); border: 1px solid var(--border-2);
+    border-radius: var(--r); box-shadow: var(--sh-3), var(--glow); overflow: hidden; }
+  .boot-bar { display: flex; align-items: center; gap: 0.5rem; padding: 0.6rem 0.9rem;
+    background: var(--tile-2); border-bottom: 1px solid var(--border); }
+  .boot-bar i { width: 11px; height: 11px; border-radius: 50%; }
+  .boot-bar i:nth-child(1){background:var(--dang)} .boot-bar i:nth-child(2){background:var(--warn)} .boot-bar i:nth-child(3){background:var(--ok)}
+  .boot-bar span { margin-left: 0.4rem; font-family: var(--fm); font-size: 0.7rem; color: var(--text-3); letter-spacing: 0.05em; }
+  .boot-body { padding: 1.1rem 1.2rem 1.3rem; min-height: 172px; }
+  .bline { font-family: var(--fm); font-size: 0.82rem; line-height: 1.9; white-space: nowrap; overflow: hidden;
+    max-width: 0; color: var(--text-2); animation: typeln .26s steps(var(--ch, 30)) forwards; animation-delay: var(--d, 0s); }
+  .bline.cmd { color: var(--accent-2); }
+  .bline .ok-tag { color: var(--ok); }
+  @keyframes typeln { from { max-width: 0; } to { max-width: 100%; } }
+  .bcaret { display: inline-block; width: 0.55em; height: 1em; background: var(--accent); vertical-align: -0.15em;
+    animation: blink 1.1s steps(1) infinite; box-shadow: 0 0 8px var(--accent-glow); }
+  .boot-skip { margin-top: 0.9rem; font-family: var(--fm); font-size: 0.62rem; color: var(--text-dim);
+    letter-spacing: 0.08em; opacity: 0; animation: fadein .4s ease 1.1s forwards; }
+  @keyframes fadein { to { opacity: 1; } }
+  @keyframes blink { 0%,100%{opacity:1} 50%{opacity:0.2} }
 
-  /* ═══ Header ═══ */
+  /* App fades up only after boot dismisses */
+  .app { opacity: 0; transform: translateY(6px); transition: opacity .55s var(--e), transform .55s var(--e); }
+  body.booted .app { opacity: 1; transform: none; }
+
+  /* ═══ App shell — header / sidebar+main / tmux bar ═══ */
+  .app { display: grid; height: 100vh; position: relative; z-index: 2; grid-template-columns: 292px 1fr;
+    grid-template-rows: auto 1fr auto; grid-template-areas: "header header" "sidebar main" "tmux tmux"; }
+
+  /* ═══ Header — shell-prompt brand ═══ */
   .hd { grid-area: header; display: flex; align-items: center; gap: 1rem;
-    padding: 0.8rem 1.5rem; background: var(--canvas); border-bottom: 1px solid var(--border); z-index: 10; }
-  .brand { display:flex; align-items:baseline; gap:0.6rem; }
-  .brand b { font-size: 1.3rem; font-weight: 700; letter-spacing: -0.02em; }
-  .brand .tag { font-size: 0.78rem; color: var(--text-3); font-family:var(--fm); }
+    padding: 0.75rem 1.5rem; background: rgba(5,5,8,0.85); backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--border); z-index: 10; }
+  .brand { display: flex; align-items: baseline; gap: 0.6rem; }
+  .brand .ps { font-family: var(--fm); font-size: 0.8rem; color: var(--text-dim); }
+  .brand b { font-size: 1.25rem; font-weight: 700; letter-spacing: -0.02em; }
+  .brand b::after { content: "▍"; color: var(--accent); margin-left: 2px; font-weight: 400;
+    animation: blink 1.4s steps(1) infinite; }
+  .brand .tag { font-size: 0.76rem; color: var(--text-3); font-family: var(--fm); }
   .hd .sp { flex: 1; }
-  .pill { display:inline-flex; align-items:center; gap:0.45rem; font-size:0.72rem; font-weight:600; font-family:var(--fm);
-    padding:0.34rem 0.72rem; border-radius:var(--r-pill); background: var(--accent-soft); color: var(--accent-2); border:1px solid var(--accent-line); }
-  .pill::before { content:""; width:7px; height:7px; border-radius:50%; background:var(--accent); box-shadow: 0 0 8px var(--accent-glow); }
-  .hd .meta { font-size:0.72rem; color:var(--text-3); font-family:var(--fm); font-variant-numeric: tabular-nums; }
-  .hd .aud { font-size:0.66rem; font-family:var(--fm); color:var(--text-2); background:var(--tile); border:1px solid var(--border);
-    border-radius:var(--r-pill); padding:0.26rem 0.6rem; letter-spacing:0.04em; }
+  .pill { display: inline-flex; align-items: center; gap: 0.45rem; font-size: 0.72rem; font-weight: 600; font-family: var(--fm);
+    padding: 0.34rem 0.72rem; border-radius: var(--r-pill); background: var(--accent-soft); color: var(--accent-2); border: 1px solid var(--accent-line); }
+  .pill::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 8px var(--accent-glow); }
+  .hd .aud { font-size: 0.66rem; font-family: var(--fm); color: var(--text-2); background: var(--tile); border: 1px solid var(--border);
+    border-radius: var(--r-pill); padding: 0.26rem 0.6rem; letter-spacing: 0.04em; }
+  .hd .palbtn { display: inline-flex; align-items: center; gap: 0.45rem; background: var(--tile); border: 1px solid var(--border);
+    border-radius: var(--r-sm); padding: 0.34rem 0.65rem; cursor: pointer; color: var(--text-3); font-size: 0.74rem;
+    font-family: var(--fm); transition: border-color .2s var(--e), color .2s var(--e); }
+  .hd .palbtn:hover { border-color: var(--accent-line); color: var(--text); }
 
   /* ═══ Sidebar ═══ */
   .sb { grid-area: sidebar; background: var(--sidebar); border-right: 1px solid var(--border);
-    overflow-y:auto; padding: 1.1rem 0.8rem 1.3rem; display:flex; flex-direction:column; gap:0.18rem; }
-  .sb-label { font-size:0.64rem; font-weight:600; letter-spacing:0.12em; text-transform:uppercase; color:var(--text-dim); padding:0.9rem 0.7rem 0.4rem; }
-  .nav { display:flex; align-items:center; gap:0.6rem; padding:0.52rem 0.7rem; border-radius:var(--r-sm);
-    font-size:0.9rem; color:var(--text-2); cursor:pointer; border:1px solid transparent; user-select:none;
-    transition: background .2s var(--e), color .2s var(--e), border-color .2s var(--e); }
-  .nav:hover { background: var(--tile-2); color: var(--text); }
-  .nav.on { background: var(--tile); color: var(--accent-2); font-weight:600; border-color: var(--border-2); }
-  .nav .d { width:9px; height:9px; border-radius:50%; flex-shrink:0; border:1.5px solid var(--text-dim); }
-  .nav .d.specced { background:var(--accent); border-color:var(--accent); box-shadow:0 0 8px var(--accent-glow); }
-  .nav .d.complete{ background:var(--ok); border-color:var(--ok); }
-  .nav .d.roadmap-only { background:transparent; border-color:var(--text-dim); }
-  .nav .n { margin-left:auto; font-family:var(--fm); font-size:0.64rem; color:var(--text-dim); font-variant-numeric:tabular-nums; }
+    overflow-y: auto; padding: 1.1rem 0.8rem 1.3rem; display: flex; flex-direction: column; gap: 0.18rem; }
+  .sb-label { font-size: 0.64rem; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); padding: 0.9rem 0.7rem 0.4rem; }
+  .nav { display: flex; align-items: center; gap: 0.6rem; padding: 0.52rem 0.7rem; border-radius: var(--r-sm);
+    font-size: 0.9rem; color: var(--text-2); cursor: pointer; border: 1px solid transparent; user-select: none; position: relative;
+    transition: background .2s var(--e), color .2s var(--e), border-color .2s var(--e), padding-left .2s var(--e); }
+  .nav::before { content: ">"; position: absolute; left: 0.45rem; font-family: var(--fm); font-size: 0.72rem;
+    color: var(--accent); opacity: 0; transform: translateX(-4px); transition: opacity .18s var(--e), transform .18s var(--e); }
+  .nav:hover { background: var(--tile-2); color: var(--text); padding-left: 1.35rem; }
+  .nav:hover::before { opacity: 1; transform: none; }
+  .nav.on { background: var(--tile); color: var(--accent-2); font-weight: 600; border-color: var(--border-2); }
+  .nav .d { width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; border: 1.5px solid var(--text-dim); }
+  .nav .d.specced { background: var(--accent); border-color: var(--accent); box-shadow: 0 0 8px var(--accent-glow); }
+  .nav .d.complete { background: var(--ok); border-color: var(--ok); }
+  .nav .d.roadmap-only { background: transparent; border-color: var(--text-dim); }
+  .nav .n { margin-left: auto; font-family: var(--fm); font-size: 0.64rem; color: var(--text-dim); font-variant-numeric: tabular-nums; }
 
-  .dodcard { margin-top:auto; padding:0.9rem; background:var(--tile); border:1px solid var(--border); border-radius:var(--r); }
-  .dodcard h4 { margin:0 0 0.6rem; font-size:0.64rem; letter-spacing:0.1em; text-transform:uppercase; color:var(--text-3); font-weight:600; }
-  .dodln { display:flex; gap:0.5rem; font-size:0.82rem; color:var(--text-2); margin-bottom:0.38rem; align-items:flex-start; }
-  .dodln .b { width:13px; height:13px; border:1.5px solid var(--border-2); border-radius:4px; flex-shrink:0; margin-top:3px; }
-  .dodln.done .b { background:var(--accent); border-color:var(--accent); box-shadow:0 0 8px var(--accent-glow); }
-  .dodln.done span { text-decoration:line-through; color:var(--text-dim); }
-  .bar { height:6px; background:var(--tile-2); border-radius:999px; overflow:hidden; margin-top:0.55rem; }
-  .bar>span { display:block; height:100%; background:linear-gradient(90deg,var(--accent-dim),var(--accent)); border-radius:999px; transition: width .6s var(--e); box-shadow:0 0 10px var(--accent-glow); }
-  .bar-m { font-size:0.64rem; color:var(--text-dim); margin-top:0.4rem; font-family:var(--fm); font-variant-numeric:tabular-nums; }
+  .dodcard { margin-top: auto; padding: 0.9rem; background: var(--tile); border: 1px solid var(--border); border-radius: var(--r); }
+  .dodcard h4 { margin: 0 0 0.6rem; font-size: 0.64rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-3); font-weight: 600; }
+  .dodln { display: flex; gap: 0.5rem; font-size: 0.82rem; color: var(--text-2); margin-bottom: 0.38rem; align-items: flex-start; }
+  .dodln .b { width: 13px; height: 13px; border: 1.5px solid var(--border-2); border-radius: 4px; flex-shrink: 0; margin-top: 3px; }
+  .dodln.done .b { background: var(--accent); border-color: var(--accent); box-shadow: 0 0 8px var(--accent-glow); }
+  .dodln.done span { text-decoration: line-through; color: var(--text-dim); }
+  /* Segmented LED bar — one cell per DoD item */
+  .segbar { display: flex; gap: 3px; margin-top: 0.55rem; }
+  .segbar i { flex: 1; height: 7px; border-radius: 2px; background: var(--tile-2); transition: background .4s var(--e), box-shadow .4s var(--e); }
+  .segbar i.on { background: var(--accent-grad); box-shadow: 0 0 8px var(--accent-glow); }
+  .bar-m { font-size: 0.64rem; color: var(--text-dim); margin-top: 0.4rem; font-family: var(--fm); font-variant-numeric: tabular-nums; }
 
-  /* ═══ Main canvas (faint green blueprint grid) ═══ */
-  .main { grid-area: main; overflow-y:auto; padding: 1.75rem 2rem 3rem; background: var(--canvas);
+  /* ═══ Main canvas ═══ */
+  .main { grid-area: main; overflow-y: auto; padding: 1.75rem 2rem 3rem; background: transparent;
     background-image: linear-gradient(var(--grid-line) 1px, transparent 1px), linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
     background-size: 32px 32px; }
-  .view { display:none; }
-  .view.on { display:block; }
+  .view { display: none; }
+  .view.on { display: block; }
 
-  /* View header — with the signature ghost numeral */
-  .vhead { margin-bottom:1.4rem; position:relative; }
-  .phase-numeral { display:block; font-family:var(--fm); font-size:5rem; font-weight:700; line-height:1;
-    color:var(--tile-2); -webkit-text-stroke:1px var(--border-2); margin-bottom:0.2rem; font-variant-numeric:tabular-nums; }
-  .eye { font-size:0.7rem; font-weight:600; letter-spacing:0.15em; text-transform:uppercase; color:var(--accent);
-    display:flex; align-items:center; gap:0.5rem; margin-bottom:0.45rem; }
-  .eye::before { content:""; width:14px; height:2px; background:var(--accent); border-radius:2px; box-shadow:0 0 6px var(--accent-glow); }
-  .vhead h1 { font-size:2.2rem; letter-spacing:-0.025em; margin:0 0 0.35rem; font-weight:700; line-height:1.1; }
-  .lead { font-size:1.05rem; color:var(--text-2); max-width:64ch; line-height:1.6; margin:0; }
-  .badges { display:flex; gap:0.5rem; align-items:center; margin-top:0.8rem; flex-wrap:wrap; }
+  /* View header — the ghost numeral now sits BEHIND the title, editorial-scale */
+  .vhead { margin-bottom: 1.4rem; position: relative; padding-top: 1.6rem; }
+  .phase-numeral { position: absolute; left: -0.45rem; top: -1.6rem; z-index: -1; font-family: var(--fm);
+    font-size: 11rem; font-weight: 700; line-height: 1; color: transparent; -webkit-text-stroke: 1px var(--border-2);
+    font-variant-numeric: tabular-nums; user-select: none; pointer-events: none;
+    -webkit-mask-image: linear-gradient(180deg, #000 30%, transparent 92%); mask-image: linear-gradient(180deg, #000 30%, transparent 92%); }
+  .eye { font-size: 0.7rem; font-weight: 600; letter-spacing: 0.15em; text-transform: uppercase; color: var(--accent);
+    display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.45rem; }
+  .eye::before { content: ""; width: 14px; height: 2px; background: var(--accent); border-radius: 2px; box-shadow: 0 0 6px var(--accent-glow); }
+  .eye::after { content: "▍"; font-weight: 400; animation: blink 1.3s steps(1) infinite; }
+  .vhead h1 { font-size: 2.4rem; letter-spacing: -0.025em; margin: 0 0 0.35rem; font-weight: 800; line-height: 1.08; }
+  .lead { font-size: 1.05rem; color: var(--text-2); max-width: 64ch; line-height: 1.6; margin: 0; }
+  .badges { display: flex; gap: 0.5rem; align-items: center; margin-top: 0.8rem; flex-wrap: wrap; }
 
-  /* Badges — neutral surface, color demoted to a single dot */
-  .bdg { display:inline-flex; align-items:center; gap:0.5rem; font-size:0.64rem; font-weight:600;
-    letter-spacing:0.08em; text-transform:uppercase; padding:0.32rem 0.72rem; border-radius:var(--r-pill);
-    background:var(--tile); color:var(--text-2); border:1px solid var(--border); }
-  .bdg::before { content:""; width:6px; height:6px; border-radius:50%; background:var(--text-dim); }
+  .bdg { display: inline-flex; align-items: center; gap: 0.5rem; font-size: 0.64rem; font-weight: 600;
+    letter-spacing: 0.08em; text-transform: uppercase; padding: 0.32rem 0.72rem; border-radius: var(--r-pill);
+    background: var(--tile); color: var(--text-2); border: 1px solid var(--border); }
+  .bdg::before { content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--text-dim); }
   .bdg.high::before{background:var(--dang)} .bdg.medium::before{background:var(--warn)} .bdg.low::before{background:var(--ok)}
   .bdg.specced::before{background:var(--accent)} .bdg.complete::before{background:var(--ok)} .bdg.roadmap-only::before{background:var(--text-dim)}
+  .bdg.active { background: var(--accent); color: var(--bg); border-color: var(--accent); }
+  .bdg.active::before { background: var(--bg); animation: blink 2s ease-in-out infinite; }
 
-  /* ═══ Tabs ═══ */
-  .tabs { display:inline-flex; gap:0.2rem; padding:0.25rem; background:var(--tile-2); border:1px solid var(--border); border-radius:var(--r-sm); margin:1.3rem 0; }
-  .tab { padding:0.5rem 1.1rem; font-size:0.9rem; font-weight:500; color:var(--text-2); cursor:pointer; border:none; background:none; border-radius:7px; font-family:var(--fs); transition: background .2s var(--e), color .2s var(--e); }
-  .tab:hover { color:var(--text); }
-  .tab.on { background:var(--tile); color:var(--accent-2); border:1px solid var(--border-2); }
-  .tab .c { font-family:var(--fm); font-size:0.64rem; color:var(--text-3); margin-left:0.4rem; font-variant-numeric:tabular-nums; }
-  .panel { display:none; }
-  .panel.on { display:block; animation: rise .34s var(--e) both; }
+  /* ═══ Tabs — terminal brackets ═══ */
+  .tabs { display: inline-flex; gap: 0.2rem; padding: 0.25rem; background: var(--tile-2); border: 1px solid var(--border); border-radius: var(--r-sm); margin: 1.3rem 0; }
+  .tab { padding: 0.5rem 1.05rem; font-size: 0.78rem; font-weight: 500; letter-spacing: 0.05em; text-transform: lowercase;
+    color: var(--text-2); cursor: pointer; border: 1px solid transparent; background: none; border-radius: 7px;
+    transition: background .2s var(--e), color .2s var(--e); }
+  .tab::before { content: "./"; color: var(--text-dim); margin-right: 1px; }
+  .tab:hover { color: var(--text); }
+  .tab.on { background: var(--tile); color: var(--accent-2); border-color: var(--border-2); }
+  .tab.on::before { color: var(--accent-dim); }
+  .tab .c { font-size: 0.64rem; color: var(--text-3); margin-left: 0.4rem; font-variant-numeric: tabular-nums; }
+  .panel { display: none; }
+  .panel.on { display: block; animation: rise .34s var(--e) both; }
   @keyframes rise { from{opacity:0; transform:translateY(8px)} to{opacity:1; transform:none} }
 
-  /* ═══ Bento grid ═══ */
-  .bento { display:grid; grid-template-columns:repeat(6,1fr); gap:0.85rem; margin-bottom:0.85rem; }
+  /* ═══ Bento grid + cursor-glow tiles ═══ */
+  .bento { display: grid; grid-template-columns: repeat(6,1fr); gap: 0.85rem; margin-bottom: 0.85rem; }
   .c2{grid-column:span 2} .c3{grid-column:span 3} .c4{grid-column:span 4} .c6{grid-column:span 6}
-  .tile { background:var(--tile); border:1px solid var(--border); border-radius:var(--r); padding:1.15rem 1.25rem;
-    position:relative; animation: rise .4s var(--e) both; animation-delay: calc(var(--i,0) * 45ms);
+  .tile { background: var(--tile); border: 1px solid var(--border); border-radius: var(--r); padding: 1.15rem 1.25rem;
+    position: relative; opacity: 0;
     transition: transform .22s var(--e), box-shadow .22s var(--e), border-color .22s var(--e); }
+  body.booted .tile { animation: rise .45s var(--e) both; animation-delay: calc(var(--i,0) * 45ms); }
   .tile:hover { transform: translateY(-2px); box-shadow: var(--sh-2); border-color: var(--border-2); }
-  .tile.hero { background:linear-gradient(135deg, var(--tile), var(--tile-2)); }
-  .tile.hero::before { content:""; position:absolute; left:0; right:0; top:0; height:1px;
-    background:linear-gradient(90deg,var(--accent),transparent); }
-  .tile.hero::after { content:""; position:absolute; left:11px; top:11px; width:9px; height:9px;
-    border-left:1.5px solid var(--accent-line); border-top:1.5px solid var(--accent-line); }
-  .tile .k { font-size:0.64rem; font-weight:600; letter-spacing:0.1em; text-transform:uppercase; color:var(--text-3); margin:0 0 0.6rem; display:flex; align-items:center; gap:0.45rem; }
-  .tile p { margin:0; color:var(--text-2); font-size:0.98rem; line-height:1.6; }
-  .tile.hero p { color:var(--text); font-size:1.02rem; }
+  /* pointer-tracking border light */
+  .tile::after { content: ""; position: absolute; inset: -1px; border-radius: inherit; padding: 1px; pointer-events: none;
+    background: radial-gradient(240px circle at var(--mx,50%) var(--my,50%), var(--accent-line), transparent 70%);
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor; mask-composite: exclude; opacity: 0; transition: opacity .3s var(--e); }
+  .tile:hover::after { opacity: 1; }
+  .tile.hero { background: linear-gradient(135deg, var(--tile), var(--tile-2)); }
+  .tile.hero::before { content: ""; position: absolute; left: 0; right: 0; top: 0; height: 1px;
+    background: linear-gradient(90deg, var(--accent), transparent); }
+  .tile .k { font-size: 0.64rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-3); margin: 0 0 0.6rem; display: flex; align-items: center; gap: 0.45rem; }
+  .tile p { margin: 0; color: var(--text-2); font-size: 0.98rem; line-height: 1.6; }
+  .tile.hero p { color: var(--text); font-size: 1.02rem; }
+  .prompt-line { font-family: var(--fm); font-size: 0.78rem; color: var(--text-dim); margin-top: 0.7rem; }
+  .prompt-line::before { content: "$ "; color: var(--accent); }
+  .prompt-line::after { content: "▍"; color: var(--accent); animation: blink 1.2s steps(1) infinite; }
 
-  .stat { display:flex; flex-direction:column; gap:0.15rem; }
-  .stat .num { font-size:2.3rem; font-weight:700; letter-spacing:-0.02em; line-height:1; font-family:var(--fm); font-variant-numeric:tabular-nums; }
-  .stat .lbl { font-size:0.7rem; color:var(--text-3); font-weight:500; }
-  .stat.accent .num { color:var(--accent); text-shadow:0 0 16px var(--accent-glow); }
+  .stat { display: flex; flex-direction: column; gap: 0.15rem; }
+  .stat .num { font-size: 2.3rem; font-weight: 700; letter-spacing: -0.02em; line-height: 1; font-family: var(--fm); font-variant-numeric: tabular-nums; }
+  .stat .lbl { font-size: 0.7rem; color: var(--text-3); font-weight: 500; }
+  .stat.accent .num { color: var(--accent); text-shadow: 0 0 16px var(--accent-glow); }
 
-  .checklist { list-style:none; margin:0; padding:0; }
-  .checklist li { display:flex; gap:0.65rem; align-items:flex-start; padding:0.5rem 0; border-bottom:1px solid var(--hair); font-size:0.92rem; color:var(--text); }
-  .checklist li:last-child { border-bottom:none; }
-  .checklist .ix { font-family:var(--fm); font-size:0.68rem; color:var(--accent-2); flex-shrink:0; background:var(--accent-soft); border:1px solid var(--border-accent,transparent); border-radius:5px; padding:0.1rem 0.4rem; margin-top:2px; font-variant-numeric:tabular-nums; }
+  /* ═══ Mission track — the roadmap as a glowing timeline ═══ */
+  .track-wrap { position: relative; padding: 0.6rem 0.2rem 0.2rem; }
+  .track { position: relative; display: grid; grid-auto-flow: column; grid-auto-columns: 1fr; }
+  .track-line { position: absolute; height: 2px; top: 13px; background: var(--tile-2); border-radius: 2px; }
+  .track-line > span { display: block; height: 100%; width: 0; background: var(--accent-grad); border-radius: 2px;
+    box-shadow: 0 0 12px var(--accent-glow); transition: width 1s var(--e) .3s; }
+  .tnode { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; background: none; border: none;
+    cursor: pointer; padding: 0 0.3rem; border-radius: var(--r-sm); transition: transform .2s var(--e); }
+  .tnode:hover { transform: translateY(-2px); }
+  .tn-dot { width: 14px; height: 14px; border-radius: 50%; border: 2px solid var(--text-dim); background: var(--canvas);
+    position: relative; z-index: 1; transition: border-color .3s var(--e), background .3s var(--e); }
+  .tnode.complete .tn-dot { background: var(--ok); border-color: var(--ok); }
+  .tnode.active .tn-dot { background: var(--accent); border-color: var(--accent); box-shadow: 0 0 10px var(--accent-glow);
+    animation: ring 2.4s ease-out infinite; }
+  .tn-num { font-size: 0.62rem; color: var(--text-dim); letter-spacing: 0.12em; font-variant-numeric: tabular-nums; }
+  .tn-name { font-size: 0.86rem; font-weight: 600; color: var(--text-2); letter-spacing: -0.005em; }
+  .tnode.active .tn-name { color: var(--accent-2); }
+  .tnode.complete .tn-name { color: var(--text); }
+  .tn-meta { font-size: 0.62rem; color: var(--text-dim); font-variant-numeric: tabular-nums; }
+  @keyframes ring { 0%{box-shadow:0 0 0 0 var(--accent-glow)} 70%{box-shadow:0 0 0 7px rgba(34,197,94,0)} 100%{box-shadow:0 0 0 0 rgba(34,197,94,0)} }
 
-  /* Edge cases — editorial entries with a ghost index. */
-  .minis { display:grid; grid-template-columns:repeat(auto-fill,minmax(250px,1fr)); gap:0.7rem; }
-  .mini { background:var(--tile-2); border:1px solid var(--border); border-radius:var(--r-sm); padding:0.95rem 1.05rem;
+  /* ═══ Task burn — per-phase progress bars ═══ */
+  .burn { display: flex; flex-direction: column; gap: 0.55rem; }
+  .burn .row { display: grid; grid-template-columns: 122px 1fr 56px; gap: 0.7rem; align-items: center; }
+  .burn .bl { font-size: 0.68rem; color: var(--text-3); letter-spacing: 0.04em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .burn .bb { height: 8px; background: var(--tile-2); border-radius: 999px; overflow: hidden; }
+  .burn .bb > span { display: block; height: 100%; width: 0; background: var(--accent-grad); border-radius: 999px;
+    box-shadow: 0 0 10px var(--accent-glow); transition: width .9s var(--e) .25s; }
+  .burn .row.hollow .bb { background: transparent; border: 1px dashed var(--border-2); }
+  .burn .bn { font-size: 0.68rem; color: var(--text-dim); text-align: right; font-variant-numeric: tabular-nums; }
+
+  .checklist { list-style: none; margin: 0; padding: 0; }
+  .checklist li { display: flex; gap: 0.65rem; align-items: flex-start; padding: 0.5rem 0; border-bottom: 1px solid var(--hair); font-size: 0.92rem; color: var(--text); }
+  .checklist li:last-child { border-bottom: none; }
+  .checklist .ix { font-family: var(--fm); font-size: 0.68rem; color: var(--accent-2); flex-shrink: 0; background: var(--accent-soft); border-radius: 5px; padding: 0.1rem 0.4rem; margin-top: 2px; font-variant-numeric: tabular-nums; }
+
+  .minis { display: grid; grid-template-columns: repeat(auto-fill,minmax(250px,1fr)); gap: 0.7rem; }
+  .mini { background: var(--tile-2); border: 1px solid var(--border); border-radius: var(--r-sm); padding: 0.95rem 1.05rem;
     transition: transform .2s var(--e), box-shadow .2s var(--e), border-color .2s var(--e); }
-  .mini:hover { transform:translateY(-2px); box-shadow:var(--sh-2); border-color:var(--border-2); }
-  .mini .ei { font-size:0.62rem; letter-spacing:0.16em; text-transform:uppercase; color:var(--text-dim); display:block; margin-bottom:0.4rem; }
-  .mini b { display:block; color:var(--text); font-weight:600; font-size:0.92rem; letter-spacing:-0.005em; margin-bottom:0.3rem; }
-  .mini b::after { content:""; display:block; width:16px; height:1.5px; background:var(--border-2); border-radius:1px; margin-top:0.45rem; transition: width .28s var(--e), background .28s var(--e); }
-  .mini:hover b::after { width:30px; background:var(--accent); box-shadow:0 0 8px var(--accent-glow); }
-  .mini .tx { font-size:0.86rem; color:var(--text-2); line-height:1.55; display:block; }
+  .mini:hover { transform: translateY(-2px); box-shadow: var(--sh-2); border-color: var(--border-2); }
+  .mini .ei { font-size: 0.62rem; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); display: block; margin-bottom: 0.4rem; }
+  .mini b { display: block; color: var(--text); font-weight: 600; font-size: 0.92rem; letter-spacing: -0.005em; margin-bottom: 0.3rem; }
+  .mini b::after { content: ""; display: block; width: 16px; height: 1.5px; background: var(--border-2); border-radius: 1px; margin-top: 0.45rem; transition: width .28s var(--e), background .28s var(--e); }
+  .mini:hover b::after { width: 30px; background: var(--accent); box-shadow: 0 0 8px var(--accent-glow); }
+  .mini .tx { font-size: 0.86rem; color: var(--text-2); line-height: 1.55; display: block; }
 
-  /* Out-of-scope chips */
-  .chips { display:flex; flex-wrap:wrap; gap:0.5rem; }
-  .chip { font-size:0.82rem; color:var(--text-dim); background:var(--tile-2); border:1px dashed var(--border-2); border-radius:var(--r-pill); padding:0.32rem 0.72rem; text-decoration:line-through; text-decoration-color:var(--border-2); }
+  .chips { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+  .chip { font-size: 0.82rem; color: var(--text-dim); background: var(--tile-2); border: 1px dashed var(--border-2); border-radius: var(--r-pill); padding: 0.32rem 0.72rem; text-decoration: line-through; text-decoration-color: var(--border-2); }
 
-  /* Trade-offs — accent check / muted cross */
-  .trades { display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); gap:0.85rem; }
-  .trade { background:var(--tile); border:1px solid var(--border); border-radius:var(--r); padding:1.1rem 1.2rem; transition: transform .22s var(--e), box-shadow .22s var(--e), border-color .22s var(--e); }
-  .trade:hover { transform:translateY(-2px); box-shadow:var(--sh-2); border-color:var(--border-2); }
-  .trade h4 { margin:0 0 0.7rem; font-size:1rem; letter-spacing:-0.01em; }
-  .trade .ln { font-size:0.88rem; padding-left:1.4rem; position:relative; margin-bottom:0.4rem; color:var(--text-2); line-height:1.55; }
-  .trade .ln.ch::before { content:"✓"; position:absolute; left:0; color:var(--accent); font-weight:700; }
-  .trade .ln.rj { color:var(--text-dim); }
-  .trade .ln.rj::before { content:"✕"; position:absolute; left:0; color:var(--text-dim); font-weight:600; }
-  .trade .ln b { color:var(--text); font-weight:600; }
-  .trade .ln.rj b { color:var(--text-2); }
-  .trade .why { font-size:0.88rem; color:var(--text-2); margin-top:0.6rem; padding-top:0.6rem; border-top:1px solid var(--hair); line-height:1.6; }
+  .trades { display: grid; grid-template-columns: repeat(auto-fit,minmax(280px,1fr)); gap: 0.85rem; }
+  .trade { background: var(--tile); border: 1px solid var(--border); border-radius: var(--r); padding: 1.1rem 1.2rem; transition: transform .22s var(--e), box-shadow .22s var(--e), border-color .22s var(--e); }
+  .trade:hover { transform: translateY(-2px); box-shadow: var(--sh-2); border-color: var(--border-2); }
+  .trade h4 { margin: 0 0 0.7rem; font-size: 1rem; letter-spacing: -0.01em; }
+  .trade .ln { font-size: 0.88rem; padding-left: 1.4rem; position: relative; margin-bottom: 0.4rem; color: var(--text-2); line-height: 1.55; }
+  .trade .ln.ch::before { content: "✓"; position: absolute; left: 0; color: var(--accent); font-weight: 700; }
+  .trade .ln.rj { color: var(--text-dim); }
+  .trade .ln.rj::before { content: "✕"; position: absolute; left: 0; color: var(--text-dim); font-weight: 600; }
+  .trade .ln b { color: var(--text); font-weight: 600; }
+  .trade .ln.rj b { color: var(--text-2); }
+  .trade .why { font-size: 0.88rem; color: var(--text-2); margin-top: 0.6rem; padding-top: 0.6rem; border-top: 1px solid var(--hair); line-height: 1.6; }
 
-  /* Component tiles — name (mono), responsibility, kind badge + file location */
-  .comps { display:grid; grid-template-columns:repeat(auto-fill,minmax(250px,1fr)); gap:0.7rem; }
-  .comp { background:var(--tile-2); border:1px solid var(--border); border-radius:var(--r-sm); padding:0.85rem 0.95rem; }
-  .comp .mn { font-family:var(--fm); font-size:0.85rem; color:var(--accent-2); margin-bottom:0.3rem; display:flex; align-items:center; gap:0.5rem; flex-wrap:wrap; }
-  .comp .kind { font-size:0.58rem; font-family:var(--fm); letter-spacing:0.06em; text-transform:uppercase; padding:0.1rem 0.42rem; border-radius:var(--r-pill); border:1px solid var(--border-2); color:var(--text-3); }
-  .comp .kind.new { color:var(--accent-2); border-color:var(--accent-line); background:var(--accent-soft); }
-  .comp .kind.modified { color:var(--warn); border-color:var(--warn); background:transparent; }
-  .comp .rs { font-size:0.86rem; color:var(--text-2); line-height:1.5; margin-bottom:0.4rem; }
-  .comp .loc { font-family:var(--fm); font-size:0.7rem; color:var(--text-dim); word-break:break-all; }
+  .comps { display: grid; grid-template-columns: repeat(auto-fill,minmax(250px,1fr)); gap: 0.7rem; }
+  .comp { background: var(--tile-2); border: 1px solid var(--border); border-radius: var(--r-sm); padding: 0.85rem 0.95rem; }
+  .comp .mn { font-family: var(--fm); font-size: 0.85rem; color: var(--accent-2); margin-bottom: 0.3rem; display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+  .comp .kind { font-size: 0.58rem; font-family: var(--fm); letter-spacing: 0.06em; text-transform: uppercase; padding: 0.1rem 0.42rem; border-radius: var(--r-pill); border: 1px solid var(--border-2); color: var(--text-3); }
+  .comp .kind.new { color: var(--accent-2); border-color: var(--accent-line); background: var(--accent-soft); }
+  .comp .kind.modified { color: var(--warn); border-color: var(--warn); }
+  .comp .rs { font-size: 0.86rem; color: var(--text-2); line-height: 1.5; margin-bottom: 0.4rem; }
+  .comp .loc { font-family: var(--fm); font-size: 0.7rem; color: var(--text-dim); word-break: break-all; }
 
-  /* Source-attribution badge in the stack table */
-  .src { font-family:var(--fm); font-size:0.68rem; letter-spacing:0.02em; padding:0.14rem 0.5rem; border-radius:var(--r-pill); border:1px solid var(--border-2); color:var(--text-3); white-space:nowrap; }
-  .src.package-json { color:var(--ok); border-color:rgba(39,201,63,0.4); }
-  .src.mcp { color:var(--accent-2); border-color:var(--accent-line); background:var(--accent-soft); }
-  .src.verify { color:var(--warn); border-color:rgba(255,189,46,0.4); }
-  .src.manual { color:var(--text-dim); }
+  .src { font-family: var(--fm); font-size: 0.68rem; letter-spacing: 0.02em; padding: 0.14rem 0.5rem; border-radius: var(--r-pill); border: 1px solid var(--border-2); color: var(--text-3); white-space: nowrap; }
+  .src.package-json { color: var(--ok); border-color: rgba(39,201,63,0.4); }
+  .src.mcp { color: var(--accent-2); border-color: var(--accent-line); background: var(--accent-soft); }
+  .src.verify { color: var(--warn); border-color: rgba(255,189,46,0.4); }
+  .src.manual { color: var(--text-dim); }
 
-  /* Data-flow stepper */
-  .flow { display:flex; flex-wrap:wrap; gap:0.5rem; align-items:stretch; }
-  .step { flex:1; min-width:160px; background:var(--tile-2); border:1px solid var(--border); border-radius:var(--r-sm); padding:0.75rem 0.85rem; }
-  .step .sn { font-family:var(--fm); font-size:0.66rem; color:var(--bg); background:var(--accent); border-radius:50%; width:20px; height:20px; display:flex; align-items:center; justify-content:center; margin-bottom:0.45rem; font-weight:700; box-shadow:0 0 10px var(--accent-glow); }
-  .step .st { font-size:0.86rem; color:var(--text-2); line-height:1.5; }
+  .flow { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: stretch; }
+  .step { flex: 1; min-width: 160px; background: var(--tile-2); border: 1px solid var(--border); border-radius: var(--r-sm); padding: 0.75rem 0.85rem; }
+  .step .sn { font-family: var(--fm); font-size: 0.66rem; color: var(--bg); background: var(--accent); border-radius: 50%; width: 20px; height: 20px; display: flex; align-items: center; justify-content: center; margin-bottom: 0.45rem; font-weight: 700; box-shadow: 0 0 10px var(--accent-glow); }
+  .step .st { font-size: 0.86rem; color: var(--text-2); line-height: 1.5; }
+  .farrow { align-self: center; color: var(--accent); font-size: 1.2rem; font-weight: 700; flex: 0 0 auto; }
 
   /* ═══ Tasks kanban ═══ */
-  .tasktop { display:flex; align-items:center; gap:1.5rem; margin-bottom:1.2rem; flex-wrap:wrap; background:var(--tile); border:1px solid var(--border); border-radius:var(--r); padding:1.1rem 1.35rem; }
-  .ring { width:64px; height:64px; flex-shrink:0; }
-  .ring .bgc { fill:none; stroke:var(--tile-2); stroke-width:3.2; }
-  .ring .fgc { fill:none; stroke:var(--accent); stroke-width:3.2; stroke-linecap:round; transition: stroke-dasharray .7s var(--e); transform:rotate(-90deg); transform-origin:center; filter:drop-shadow(0 0 4px var(--accent-glow)); }
-  .ring-wrap { position:relative; }
-  .ring-pct { position:absolute; inset:0; display:flex; align-items:center; justify-content:center; font-size:0.85rem; font-weight:700; font-family:var(--fm); font-variant-numeric:tabular-nums; }
-  .tasktop .summ b { font-size:1.6rem; font-weight:700; font-variant-numeric:tabular-nums; letter-spacing:-0.02em; font-family:var(--fm); }
-  .tasktop .summ .s2 { font-size:0.86rem; color:var(--text-3); }
-  .grpstats { display:flex; gap:1.1rem; margin-left:auto; flex-wrap:wrap; }
-  .gst { text-align:center; }
-  .gst .gn { font-size:1.15rem; font-weight:600; font-family:var(--fm); font-variant-numeric:tabular-nums; }
-  .gst .gl { font-size:0.64rem; color:var(--text-dim); text-transform:uppercase; letter-spacing:0.06em; }
+  .tasktop { display: flex; align-items: center; gap: 1.5rem; margin-bottom: 1.2rem; flex-wrap: wrap; background: var(--tile); border: 1px solid var(--border); border-radius: var(--r); padding: 1.1rem 1.35rem; }
+  .ring { width: 64px; height: 64px; flex-shrink: 0; }
+  .ring .bgc { fill: none; stroke: var(--tile-2); stroke-width: 3.2; }
+  .ring .fgc { fill: none; stroke: var(--accent); stroke-width: 3.2; stroke-linecap: round; transition: stroke-dasharray .7s var(--e); transform: rotate(-90deg); transform-origin: center; filter: drop-shadow(0 0 4px var(--accent-glow)); }
+  .ring-wrap { position: relative; }
+  .ring-pct { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; font-size: 0.85rem; font-weight: 700; font-family: var(--fm); font-variant-numeric: tabular-nums; }
+  .tasktop .summ b { font-size: 1.6rem; font-weight: 700; font-variant-numeric: tabular-nums; letter-spacing: -0.02em; font-family: var(--fm); }
+  .tasktop .summ .s2 { font-size: 0.86rem; color: var(--text-3); }
+  .grpstats { display: flex; gap: 1.1rem; margin-left: auto; flex-wrap: wrap; }
+  .gst { text-align: center; }
+  .gst .gn { font-size: 1.15rem; font-weight: 600; font-family: var(--fm); font-variant-numeric: tabular-nums; }
+  .gst .gl { font-size: 0.64rem; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.06em; }
 
-  .kanban { display:grid; grid-template-columns:repeat(3,1fr); gap:0.85rem; align-items:start; }
-  .kcol { background:var(--tile-2); border:1px solid var(--border); border-radius:var(--r); padding:0.7rem; }
-  .kcol h3 { margin:0 0 0.7rem; font-size:0.7rem; letter-spacing:0.08em; text-transform:uppercase; color:var(--text-3); font-weight:600; display:flex; align-items:center; gap:0.5rem; padding:0.2rem 0.35rem; }
-  .kcol h3 .kc { margin-left:auto; font-family:var(--fm); background:var(--tile); border:1px solid var(--border); border-radius:var(--r-pill); padding:0.05rem 0.45rem; font-size:0.64rem; color:var(--text-2); }
-  .kcard { background:var(--tile); border:1px solid var(--border); border-radius:var(--r-sm); margin-bottom:0.55rem; overflow:hidden; transition: box-shadow .2s var(--e), border-color .2s var(--e); }
-  .kcard:hover { box-shadow:var(--sh-2); border-color:var(--border-2); }
-  .kcard .top { display:flex; gap:0.6rem; align-items:flex-start; padding:0.7rem 0.8rem; cursor:pointer; }
-  .ck { width:19px; height:19px; border:1.6px solid var(--border-2); border-radius:5px; flex-shrink:0; position:relative; margin-top:1px; transition: background .15s var(--e), border-color .15s var(--e), box-shadow .15s var(--e); }
-  .kcard.done .ck { background:var(--accent); border-color:var(--accent); box-shadow:0 0 10px var(--accent-glow); }
-  .kcard.done .ck::after { content:""; position:absolute; left:6px; top:2px; width:5px; height:10px; border:solid var(--bg); border-width:0 2px 2px 0; transform:rotate(45deg); animation: pop .26s var(--spring); }
+  .kanban { display: grid; grid-template-columns: repeat(3,1fr); gap: 0.85rem; align-items: start; }
+  .kcol { background: var(--tile-2); border: 1px solid var(--border); border-radius: var(--r); padding: 0.7rem; }
+  .kcol h3 { margin: 0 0 0.45rem; font-size: 0.7rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-3); font-weight: 600; display: flex; align-items: center; gap: 0.5rem; padding: 0.2rem 0.35rem; }
+  .kcol h3 .kc { margin-left: auto; font-family: var(--fm); background: var(--tile); border: 1px solid var(--border); border-radius: var(--r-pill); padding: 0.05rem 0.45rem; font-size: 0.64rem; color: var(--text-2); }
+  .kprog { height: 3px; border-radius: 2px; background: var(--tile); overflow: hidden; margin: 0 0.35rem 0.7rem; }
+  .kprog > span { display: block; height: 100%; background: var(--accent-grad); border-radius: 2px; transition: width .8s var(--e) .2s; }
+  .kcard { background: var(--tile); border: 1px solid var(--border); border-radius: var(--r-sm); margin-bottom: 0.55rem; overflow: hidden; transition: box-shadow .2s var(--e), border-color .2s var(--e); }
+  .kcard:hover { box-shadow: var(--sh-2); border-color: var(--border-2); }
+  .kcard .top { display: flex; gap: 0.6rem; align-items: flex-start; padding: 0.7rem 0.8rem; cursor: pointer; }
+  .ck { width: 19px; height: 19px; border: 1.6px solid var(--border-2); border-radius: 5px; flex-shrink: 0; position: relative; margin-top: 1px; transition: background .15s var(--e), border-color .15s var(--e), box-shadow .15s var(--e); }
+  .kcard.done .ck { background: var(--accent); border-color: var(--accent); box-shadow: 0 0 10px var(--accent-glow); }
+  .kcard.done .ck::after { content: ""; position: absolute; left: 6px; top: 2px; width: 5px; height: 10px; border: solid var(--bg); border-width: 0 2px 2px 0; transform: rotate(45deg); animation: pop .26s var(--spring); }
   @keyframes pop { 0%{transform:rotate(45deg) scale(0)} 60%{transform:rotate(45deg) scale(1.2)} 100%{transform:rotate(45deg) scale(1)} }
-  .kcard .id { font-family:var(--fm); font-size:0.68rem; color:var(--text-dim); flex-shrink:0; margin-top:3px; font-variant-numeric:tabular-nums; }
-  .kcard .tx { font-size:0.88rem; color:var(--text); line-height:1.45; flex:1; }
-  .kcard.done .tx { text-decoration:line-through; color:var(--text-dim); }
-  .kcard .cv { color:var(--text-dim); font-size:0.7rem; flex-shrink:0; margin-top:3px; transition:transform .2s var(--e); }
-  .kcard.open .cv { transform:rotate(90deg); }
-  .kcard .det { display:none; padding:0 0.8rem 0.8rem 2.55rem; font-size:0.84rem; color:var(--text-2); line-height:1.55; }
-  .kcard.open .det { display:block; }
+  .kcard .id { font-family: var(--fm); font-size: 0.68rem; color: var(--text-dim); flex-shrink: 0; margin-top: 3px; font-variant-numeric: tabular-nums; }
+  .kcard .tx { font-size: 0.88rem; color: var(--text); line-height: 1.45; flex: 1; }
+  .kcard.done .tx { text-decoration: line-through; color: var(--text-dim); }
+  .kcard .cv { color: var(--text-dim); font-size: 0.7rem; flex-shrink: 0; margin-top: 3px; transition: transform .2s var(--e); }
+  .kcard.open .cv { transform: rotate(90deg); }
+  .kcard .det { display: none; padding: 0 0.8rem 0.8rem 2.55rem; font-size: 0.84rem; color: var(--text-2); line-height: 1.55; }
+  .kcard.open .det { display: block; }
 
-  .note { padding:1.5rem; border:1px dashed var(--border-2); border-radius:var(--r); background:var(--tile-2); color:var(--text-2); font-size:0.98rem; }
-  .note code { background:var(--tile); padding:0.1em 0.45em; border-radius:5px; font-family:var(--fm); font-size:0.85em; color:var(--accent-2); }
+  .note { padding: 1.5rem; border: 1px dashed var(--border-2); border-radius: var(--r); background: var(--tile-2); color: var(--text-2); font-size: 0.98rem; }
+  .note code { background: var(--tile); padding: 0.1em 0.45em; border-radius: 5px; font-family: var(--fm); font-size: 0.85em; color: var(--accent-2); }
 
-  table { width:100%; border-collapse:collapse; font-size:0.92rem; }
-  thead th { text-align:left; font-size:0.64rem; letter-spacing:0.08em; text-transform:uppercase; color:var(--text-dim); font-weight:600; padding:0.55rem 0.7rem; border-bottom:1px solid var(--border-2); }
-  tbody td { padding:0.6rem 0.7rem; border-bottom:1px solid var(--hair); vertical-align:top; }
-  tbody tr:last-child td { border-bottom:none; }
-  tbody tr:hover td { background:var(--tile-2); }
-  .mono { font-family:var(--fm); font-size:0.85rem; }
-  .inl { background:var(--tile); padding:0.1em 0.42em; border-radius:5px; font-family:var(--fm); font-size:0.85em; color:var(--accent-2); }
+  table { width: 100%; border-collapse: collapse; font-size: 0.92rem; }
+  thead th { text-align: left; font-size: 0.64rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); font-weight: 600; padding: 0.55rem 0.7rem; border-bottom: 1px solid var(--border-2); }
+  tbody td { padding: 0.6rem 0.7rem; border-bottom: 1px solid var(--hair); vertical-align: top; }
+  tbody tr:last-child td { border-bottom: none; }
+  tbody tr:hover td { background: var(--tile-2); }
+  .mono { font-family: var(--fm); font-size: 0.85rem; }
+  .inl { background: var(--tile); padding: 0.1em 0.42em; border-radius: 5px; font-family: var(--fm); font-size: 0.85em; color: var(--accent-2); }
 
-  /* Active phase — calm but unmistakable, with green glow */
-  .nav.active-phase { background:var(--accent-soft); color:var(--accent-2); font-weight:600; box-shadow: inset 3px 0 0 var(--accent); }
-  .nav.active-phase:hover { background:var(--accent-soft); }
+  .nav.active-phase { background: var(--accent-soft); color: var(--accent-2); font-weight: 600; box-shadow: inset 3px 0 0 var(--accent); }
+  .nav.active-phase:hover { background: var(--accent-soft); }
   .nav.active-phase .d { animation: ring 2.4s ease-out infinite; }
-  @keyframes ring { 0%{box-shadow:0 0 0 0 var(--accent-glow)} 70%{box-shadow:0 0 0 6px rgba(34,197,94,0)} 100%{box-shadow:0 0 0 0 rgba(34,197,94,0)} }
-  .atag { margin-left:auto; font-size:0.56rem; font-weight:700; font-family:var(--fm); letter-spacing:0.08em; text-transform:uppercase; color:var(--bg); background:var(--accent); border-radius:var(--r-pill); padding:0.12rem 0.5rem; box-shadow:0 0 10px var(--accent-glow); }
-  .bdg.active { background:var(--accent); color:var(--bg); border-color:var(--accent); }
-  .bdg.active::before { background:var(--bg); animation: blink 2s ease-in-out infinite; }
-  @keyframes blink { 0%,100%{opacity:1} 50%{opacity:0.35} }
+  .atag { margin-left: auto; font-size: 0.56rem; font-weight: 700; font-family: var(--fm); letter-spacing: 0.08em; text-transform: uppercase; color: var(--bg); background: var(--accent); border-radius: var(--r-pill); padding: 0.12rem 0.5rem; box-shadow: 0 0 10px var(--accent-glow); }
 
-  /* User stories */
-  .stories { display:grid; grid-template-columns:repeat(auto-fit,minmax(290px,1fr)); gap:0.7rem; }
-  .story { background:var(--tile-2); border:1px solid var(--border); border-left:3px solid var(--accent); border-radius:var(--r-sm); padding:0.9rem 1rem; font-size:0.9rem; color:var(--text); line-height:1.65; }
-  .story .sa { font-size:0.62rem; font-weight:700; font-family:var(--fm); letter-spacing:0.08em; text-transform:uppercase; color:var(--accent-2); margin-right:0.35rem; }
+  .stories { display: grid; grid-template-columns: repeat(auto-fit,minmax(290px,1fr)); gap: 0.7rem; }
+  .story { background: var(--tile-2); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: var(--r-sm); padding: 0.9rem 1rem; font-size: 0.9rem; color: var(--text); line-height: 1.65; }
+  .story .sa { font-size: 0.62rem; font-weight: 700; font-family: var(--fm); letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent-2); margin-right: 0.35rem; }
 
-  /* Open-questions list */
-  .qlist { margin:0; padding:0; list-style:none; }
-  .qlist li { color:var(--text-2); font-size:0.9rem; margin-bottom:0.5rem; line-height:1.55; padding-left:1.4rem; position:relative; }
-  .qlist li::before { content:"?"; position:absolute; left:0; top:-1px; color:var(--accent); font-weight:700; font-family:var(--fm); }
+  .qlist { margin: 0; padding: 0; list-style: none; }
+  .qlist li { color: var(--text-2); font-size: 0.9rem; margin-bottom: 0.5rem; line-height: 1.55; padding-left: 1.4rem; position: relative; }
+  .qlist li::before { content: "?"; position: absolute; left: 0; top: -1px; color: var(--accent); font-weight: 700; font-family: var(--fm); }
 
-  /* Architecture SVG diagram */
-  .archwrap { padding:0.5rem 0.25rem 0.25rem; }
-  .archsvg { width:100%; height:auto; display:block; }
-  .al-lbl { font-family:var(--fm); font-size:10px; fill:var(--text-dim); letter-spacing:0.03em; }
-  .al-box { fill:var(--tile-2); stroke:var(--border-2); stroke-width:1; }
-  .al-node { font-family:var(--fm); font-size:11px; fill:var(--text); }
-  .al-arrow { stroke:var(--accent); stroke-width:1.5; }
-  .al-head { fill:var(--accent); }
-  .archcap { font-size:0.86rem; color:var(--text-3); font-style:italic; margin-top:0.7rem; line-height:1.55; }
+  /* Architecture SVG — connectors march; diagram stays diagram-sized
+     (capped + centered) instead of stretching to fill a 6-col tile */
+  .archwrap { padding: 0.5rem 0.25rem 0.25rem; }
+  .archsvg { width: 100%; max-width: 700px; height: auto; display: block; margin: 0 auto; }
+  .al-lbl { font-family: var(--fm); font-size: 10px; fill: var(--text-dim); letter-spacing: 0.03em; }
+  .al-box { fill: var(--tile-2); stroke: var(--border-2); stroke-width: 1; }
+  .al-node { font-family: var(--fm); font-size: 11px; fill: var(--text); }
+  .al-arrow { stroke: var(--accent); stroke-width: 1.5; stroke-dasharray: 5 4; animation: march 1.1s linear infinite; }
+  @keyframes march { to { stroke-dashoffset: -9; } }
+  .al-head { fill: var(--accent); }
+  .archcap { font-size: 0.86rem; color: var(--text-3); font-style: italic; margin-top: 0.7rem; line-height: 1.55; }
 
-  /* Flow connectors */
-  .farrow { align-self:center; color:var(--accent); font-size:1.2rem; font-weight:700; flex:0 0 auto; }
+  /* ═══ tmux status bar ═══ */
+  .tmx { grid-area: tmux; display: flex; align-items: stretch; gap: 1px; background: var(--sidebar);
+    border-top: 1px solid var(--border); font-size: 0.68rem; line-height: 1; z-index: 10; user-select: none; }
+  .seg { display: inline-flex; align-items: center; gap: 0.45rem; padding: 0.5rem 0.85rem; color: var(--text-3);
+    letter-spacing: 0.04em; font-variant-numeric: tabular-nums; background: var(--canvas); white-space: nowrap; }
+  .seg.brand { background: var(--accent); color: var(--bg); font-weight: 700; letter-spacing: 0.08em; }
+  .seg.okk { color: var(--accent-2); }
+  .seg b { color: var(--text-2); font-weight: 600; }
+  .tmx .sp { flex: 1; background: var(--canvas); }
+  .seg.ghost { color: var(--text-dim); }
+  .seg.time { color: var(--text-2); }
 
-  @media (prefers-reduced-motion: reduce) { *,*::before,*::after { animation-duration:.001ms!important; transition-duration:.001ms!important; } }
-  @media (max-width: 1080px) { .bento{grid-template-columns:repeat(4,1fr)} .c4,.c6{grid-column:span 4} .c3{grid-column:span 2} .kanban{grid-template-columns:1fr} }
+  /* ═══ ⌘K command palette ═══ */
+  .pal { position: fixed; inset: 0; z-index: 10001; display: flex; align-items: flex-start; justify-content: center;
+    padding-top: 14vh; background: rgba(3,3,5,0.7); backdrop-filter: blur(4px); }
+  .pal[hidden] { display: none; }
+  .pal-box { width: min(520px, 90vw); background: var(--sidebar); border: 1px solid var(--accent-line);
+    border-radius: var(--r); box-shadow: var(--sh-3), var(--glow); overflow: hidden; animation: palin .22s var(--spring) both; }
+  @keyframes palin { from { opacity: 0; transform: translateY(-10px) scale(0.98); } to { opacity: 1; transform: none; } }
+  .pal-top { display: flex; align-items: center; gap: 0.6rem; padding: 0.85rem 1rem; border-bottom: 1px solid var(--border); }
+  .pal-ps { font-family: var(--fm); font-size: 0.85rem; color: var(--accent); }
+  .pal-top input { flex: 1; background: none; border: none; outline: none; color: var(--text);
+    font-family: var(--fm); font-size: 0.95rem; caret-color: var(--accent); }
+  .pal-top input::placeholder { color: var(--text-dim); }
+  .pal-ls { list-style: none; margin: 0; padding: 0.4rem; max-height: 300px; overflow-y: auto; }
+  .pal-ls li { display: flex; align-items: center; gap: 0.7rem; padding: 0.55rem 0.7rem; border-radius: var(--r-sm);
+    font-size: 0.9rem; color: var(--text-2); cursor: pointer; }
+  .pal-ls li .pd { width: 8px; height: 8px; border-radius: 50%; border: 1.5px solid var(--text-dim); flex-shrink: 0; }
+  .pal-ls li .pd.complete { background: var(--ok); border-color: var(--ok); }
+  .pal-ls li .pd.specced { background: var(--accent); border-color: var(--accent); }
+  .pal-ls li .pk { margin-left: auto; }
+  .pal-ls li.sel { background: var(--accent-soft); color: var(--accent-2); }
+  .pal-ls li.sel .pd { border-color: var(--accent); }
+  .pal-hint { padding: 0.55rem 1rem; border-top: 1px solid var(--border); font-family: var(--fm);
+    font-size: 0.62rem; color: var(--text-dim); letter-spacing: 0.06em; }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,*::before,*::after { animation-duration: .001ms !important; transition-duration: .001ms !important; }
+    .sweep, .aurora { display: none; }
+  }
+  @media (max-width: 1080px) { .bento{grid-template-columns:repeat(4,1fr)} .c4,.c6{grid-column:span 4} .c3{grid-column:span 2} .kanban{grid-template-columns:1fr} .phase-numeral{font-size:7.5rem} }
   @media (max-width: 760px) {
-    .app{grid-template-columns:1fr; grid-template-areas:"header" "sidebar" "main"; height:auto}
+    .app{grid-template-columns:1fr; grid-template-rows:auto auto 1fr auto; grid-template-areas:"header" "sidebar" "main" "tmux"; height:100vh}
     .sb{flex-direction:row; flex-wrap:wrap; overflow:visible; border-right:none; border-bottom:1px solid var(--border)}
     .dodcard{width:100%}
     .bento{grid-template-columns:repeat(2,1fr)} .c2,.c3,.c4,.c6{grid-column:span 2}
     .main{padding:1.25rem 1rem 2.5rem}
+    .phase-numeral{font-size:5.5rem}
+    .burn .row{grid-template-columns:90px 1fr 50px}
+    .tmx{flex-wrap:wrap}
   }
 </style>
 </head>
 <body>
+
+<div class="aurora" aria-hidden="true"><i></i><i></i></div>
+<div class="sweep" aria-hidden="true"></div>
+
+<!-- Boot sequence -->
+<div class="boot" id="boot" role="status" aria-label="Loading dashboard">
+  <div>
+    <div class="boot-win">
+      <div class="boot-bar"><i></i><i></i><i></i><span>own — dashboard</span></div>
+      <div class="boot-body" id="bootBody"></div>
+    </div>
+    <div class="boot-skip">press any key to skip</div>
+  </div>
+</div>
+
 <div class="app">
   <header class="hd">
-    <div class="brand"><b>—</b><span class="tag">project dashboard</span></div>
+    <div class="brand"><span class="ps">~/</span><b>—</b><span class="tag">project dashboard</span></div>
     <div class="sp"></div>
     <span class="aud" id="hdAud" hidden>—</span>
     <span class="pill" id="gStatus">—</span>
-    <span class="meta" id="hdMeta">—</span>
+    <button class="palbtn" id="palBtn" aria-label="Open command palette">jump <kbd>⌘K</kbd></button>
   </header>
   <aside class="sb" id="sb">
     <div class="sb-label">Project</div>
@@ -354,11 +503,21 @@
     <div class="dodcard">
       <h4>Definition of Done</h4>
       <div id="dod"></div>
-      <div class="bar"><span id="dodBar" style="width:0%"></span></div>
+      <div class="segbar" id="dodSeg"></div>
       <div class="bar-m" id="dodMeta">—</div>
     </div>
   </aside>
   <main class="main" id="main"></main>
+  <footer class="tmx" id="tmx" aria-hidden="true"></footer>
+</div>
+
+<!-- ⌘K palette -->
+<div class="pal" id="pal" hidden>
+  <div class="pal-box" role="dialog" aria-label="Command palette">
+    <div class="pal-top"><span class="pal-ps">~ $</span><input id="palIn" placeholder="jump to view…" autocomplete="off" spellcheck="false" /></div>
+    <ul class="pal-ls" id="palLs"></ul>
+    <div class="pal-hint">↑↓ navigate · ↵ go · esc close · tip: digits 1–9 jump, [ ] cycle views</div>
+  </div>
 </div>
 
 <!-- DATA: the single file the /own:* commands rewrite to keep this in sync -->
@@ -369,13 +528,13 @@ const $ = (s,r=document)=>r.querySelector(s);
 const esc = s => String(s ?? "").replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 const tile = (cls, body, idx) => `<div class="tile ${cls}" style="--i:${idx}">${body}</div>`;
 const pad2 = k => String(k).padStart(2,"0");
+const REDUCED = matchMedia("(prefers-reduced-motion: reduce)").matches;
+/* the handler accepts metaKey OR ctrlKey everywhere — this only fixes the label */
+const MODK = (typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform || navigator.userAgent)) ? "⌘" : "Ctrl+";
 
-/* meta.audience enum → human label (see DASHBOARD_CONTRACT §3.1) */
 const AUDIENCE_LABEL = { "myself":"For: Myself", "employers":"For: Employers",
   "clients":"For: Clients", "real-users":"For: Real users" };
 
-/* stack source attribution (col 3) → css class + display.
-   Values: "package.json" | "mcp:YYYY-MM-DD" | "verify:URL" | "manual" */
 function srcBadge(source){
   const s = String(source ?? "manual");
   if (s === "package.json") return `<span class="src package-json">package.json</span>`;
@@ -384,19 +543,37 @@ function srcBadge(source){
   return `<span class="src manual">manual</span>`;
 }
 
-/* Hand-rolled SVG architecture diagram — layered bands + arrowed connectors.
-   No library, no network: works on file://. Redraws from the data. */
 function renderArch(d){
-  const W=620, padL=92, areaW=W-padL-10, gap=16, bandH=54, vGap=30;
-  const n=d.layers.length, H=n*bandH+(n-1)*vGap+12;
-  let y=6, s="";
+  /* Content-aware layout. JetBrains Mono glyphs are ≈ CH × font-size wide,
+     so text needs are computable: the label gutter fits the longest label
+     (capped at 30% width), and node boxes size to their text — scaled down
+     proportionally on crowded rows, shrinking type (floor 8px) and finally
+     ellipsizing. Clipped text keeps its full value as a hover <title>. */
+  const W=640, gap=14, bandH=42, vGap=26, minBox=60, maxBox=260;
+  const LBL_FS=10, NODE_FS=11, CH=0.62;
+  const clip=(t,max)=> t.length>max ? t.slice(0, Math.max(1,max-1))+"…" : t;
+  const labels=d.layers.map(L=>String(L.label));
+  const padL=Math.min(Math.ceil(Math.max(...labels.map(t=>t.length))*LBL_FS*CH)+14, Math.floor(W*0.3));
+  const lblMax=Math.floor((padL-14)/(LBL_FS*CH));
+  const areaW=W-padL-8;
+  const n=d.layers.length, H=n*bandH+(n-1)*vGap+10;
+  let y=5, s="";
   d.layers.forEach((L,li)=>{
-    s+=`<text x="0" y="${y+bandH/2}" class="al-lbl" dominant-baseline="middle">${esc(L.label)}</text>`;
-    const k=L.nodes.length, bw=(areaW-(k-1)*gap)/k;
+    const lbl=clip(labels[li], lblMax);
+    s+=`<text x="0" y="${y+bandH/2}" class="al-lbl" dominant-baseline="middle">${esc(lbl)}${lbl!==labels[li]?`<title>${esc(labels[li])}</title>`:""}</text>`;
+    const k=L.nodes.length, availTotal=areaW-(k-1)*gap;
+    const needs=L.nodes.map(t=>Math.min(Math.max(String(t).length*NODE_FS*CH+22, minBox), maxBox));
+    const scale=Math.min(1, availTotal/needs.reduce((a,b)=>a+b,0));
+    const widths=needs.map(w=>w*scale);
+    let x=padL+(areaW-(widths.reduce((a,b)=>a+b,0)+(k-1)*gap))/2;
     L.nodes.forEach((node,ni)=>{
-      const x=padL+ni*(bw+gap);
+      const bw=widths[ni], txt=String(node);
+      let fs=NODE_FS;
+      if(txt.length*fs*CH+12>bw) fs=Math.max(8, (bw-12)/(txt.length*CH));
+      const shown=clip(txt, Math.floor((bw-12)/(fs*CH)));
       s+=`<rect x="${x}" y="${y}" width="${bw}" height="${bandH}" rx="9" class="al-box"/>`;
-      s+=`<text x="${x+bw/2}" y="${y+bandH/2}" class="al-node" text-anchor="middle" dominant-baseline="middle">${esc(node)}</text>`;
+      s+=`<text x="${x+bw/2}" y="${y+bandH/2}" class="al-node" style="font-size:${fs.toFixed(1)}px" text-anchor="middle" dominant-baseline="middle">${esc(shown)}${shown!==txt?`<title>${esc(txt)}</title>`:""}</text>`;
+      x+=bw+gap;
     });
     if(li<n-1){ const ax=padL+areaW/2, y1=y+bandH, y2=y+bandH+vGap;
       s+=`<line x1="${ax}" y1="${y1}" x2="${ax}" y2="${y2-6}" class="al-arrow"/>`;
@@ -407,13 +584,18 @@ function renderArch(d){
 }
 
 function activePhase(){ return PROJECT.phases.find(p => p.status !== "complete"); }
+function taskTotals(){
+  let d=0,t=0;
+  PROJECT.phases.forEach(p=>{ if(p.tasks){ t+=p.tasks.length; d+=p.tasks.filter(x=>x.done).length; } });
+  return {d,t};
+}
 
 function renderHeader(){
   const m = PROJECT.meta;
+  $("#palBtn").innerHTML = `jump <kbd>${MODK}K</kbd>`;
   document.title = `${m.name} · Project Dashboard`;
   $(".brand b").textContent = m.name;
   $(".brand .tag").textContent = m.tagline || "project dashboard";
-  $("#hdMeta").textContent = m.generated + " · v" + m.version;
   if (m.audience && AUDIENCE_LABEL[m.audience]) {
     const a = $("#hdAud"); a.textContent = AUDIENCE_LABEL[m.audience]; a.hidden = false;
   }
@@ -437,8 +619,28 @@ function renderSidebar(){
   PROJECT.dod.forEach(x=>{ const l=document.createElement("div"); l.className="dodln"+(x.done?" done":"");
     l.innerHTML=`<span class="b"></span><span>${esc(x.text)}</span>`; dod.appendChild(l); });
   const done = PROJECT.dod.filter(d=>d.done).length;
-  const pct = PROJECT.dod.length ? Math.round(done/PROJECT.dod.length*100) : 0;
-  $("#dodBar").style.width = pct+"%"; $("#dodMeta").textContent = `${done} / ${PROJECT.dod.length} complete`;
+  const seg = $("#dodSeg");
+  PROJECT.dod.forEach((x)=>{ const i=document.createElement("i"); if(x.done) i.className="on"; seg.appendChild(i); });
+  $("#dodMeta").textContent = `${done} / ${PROJECT.dod.length} complete`;
+}
+
+/* tmux bar — live status segments + clock */
+function renderTmux(){
+  const m=PROJECT.meta, cur=activePhase(), {d,t}=taskTotals();
+  const dodD=PROJECT.dod.filter(x=>x.done).length;
+  const dodPct=PROJECT.dod.length?Math.round(dodD/PROJECT.dod.length*100):0;
+  $("#tmx").innerHTML = `
+    <span class="seg brand">OWN v${esc(m.version)}</span>
+    <span class="seg">~/${esc(m.name)}</span>
+    <span class="seg okk">${cur?`phase ${cur.n}/${PROJECT.phases.length}`:"all phases complete"}</span>
+    <span class="seg">tasks <b>${d}/${t}</b></span>
+    <span class="seg">dod <b>${dodPct}%</b></span>
+    <span class="sp"></span>
+    <span class="seg ghost">${MODK}K jump</span>
+    <span class="seg">${esc(m.generated)}</span>
+    <span class="seg time" id="clock">—:—:—</span>`;
+  const tick=()=>{ const c=$("#clock"); if(c) c.textContent=new Date().toLocaleTimeString("en-GB",{hour12:false}); };
+  tick(); setInterval(tick, 1000);
 }
 
 function renderViews(){
@@ -448,11 +650,48 @@ function renderViews(){
   PROJECT.phases.forEach(p=> main.appendChild(viewPhase(p)));
 }
 
+/* Mission track — the roadmap as a timeline */
+function missionTrack(){
+  const ps=PROJECT.phases; if(!ps.length) return "";
+  const total=ps.length, activeN=(activePhase()||{}).n;
+  const completeN=ps.filter(p=>p.status==="complete").length;
+  let frac=completeN;
+  const cur=activePhase();
+  if(cur&&cur.tasks&&cur.tasks.length) frac+=cur.tasks.filter(t=>t.done).length/cur.tasks.length;
+  const pct=Math.min(100, frac/total*100);
+  const half=(50/total);
+  const nodes=ps.map(p=>{
+    const cls=p.status==="complete"?"complete":p.n===activeN?"active":"roadmap";
+    const meta=p.tasks?`${p.tasks.filter(t=>t.done).length}/${p.tasks.length} tasks`:`${(p.items||[]).length} planned`;
+    return `<button class="tnode ${cls}" data-v="phase-${p.n}" aria-label="Go to phase ${p.n}">
+      <span class="tn-dot"></span><span class="tn-num">${pad2(p.n)}</span>
+      <span class="tn-name">${esc(p.name)}</span><span class="tn-meta">${meta}</span></button>`;
+  }).join("");
+  return `<div class="track-wrap">
+    <div class="track">
+      <div class="track-line" style="left:${half}%; right:${half}%"><span data-w="${pct}"></span></div>
+      ${nodes}
+    </div></div>`;
+}
+
+/* Task burn — one bar per phase */
+function taskBurn(){
+  if(!PROJECT.phases.length) return "";
+  const rows=PROJECT.phases.map(p=>{
+    if(p.tasks&&p.tasks.length){
+      const d=p.tasks.filter(t=>t.done).length, pct=Math.round(d/p.tasks.length*100);
+      return `<div class="row"><span class="bl">P${p.n} ${esc(p.name)}</span><div class="bb"><span data-w="${pct}"></span></div><span class="bn">${d}/${p.tasks.length}</span></div>`;
+    }
+    return `<div class="row hollow"><span class="bl">P${p.n} ${esc(p.name)}</span><div class="bb"><span data-w="0"></span></div><span class="bn">—</span></div>`;
+  }).join("");
+  return `<div class="burn">${rows}</div>`;
+}
+
 function viewOverview(){
   const v=document.createElement("div"); v.className="view on"; v.id="view-overview";
   const m = PROJECT.meta;
   const complete = PROJECT.phases.filter(p=>p.status==="complete");
-  const taskTotal = PROJECT.phases.reduce((s,p)=>s+(p.tasks?p.tasks.length:0),0);
+  const {d:taskDone,t:taskTotal}=taskTotals();
   const cur = activePhase();
   let next;
   if (!PROJECT.phases.length) next = "This dashboard is empty. Run <span class='inl'>/own:init</span> to define your mission, stack, and roadmap.";
@@ -464,14 +703,18 @@ function viewOverview(){
     <div class="vhead"><div class="eye">Project Mission</div><h1>${esc(m.name)}</h1>
       <p class="lead">${esc(m.tagline||"")}</p></div>
     <div class="bento">
-      ${tile("hero c4","<div class='k'>The problem</div><p>"+esc(m.mission)+"</p>",n++)}
-      ${tile("stat c2 accent","<span class='num'>"+PROJECT.phases.length+"</span><span class='lbl'>Roadmap phases</span>",n++)}
-      ${tile("stat c2","<span class='num'>"+taskTotal+"</span><span class='lbl'>Tasks specced</span>",n++)}
-      ${tile("stat c2","<span class='num'>"+complete.length+"</span><span class='lbl'>Phases complete</span>",n++)}
+      ${tile("hero c4","<div class='k'>The problem</div><p>"+esc(m.mission)+"</p><div class='prompt-line'>own the code you ship</div>",n++)}
+      ${tile("stat c2 accent","<span class='num' data-count='"+PROJECT.phases.length+"'>0</span><span class='lbl'>Roadmap phases</span>",n++)}
+      ${tile("stat c2","<span class='num' data-count='"+taskTotal+"'>0</span><span class='lbl'>Tasks specced</span>",n++)}
+      ${tile("stat c2","<span class='num' data-count='"+taskDone+"'>0</span><span class='lbl'>Tasks complete</span>",n++)}
       ${tile("c2","<div class='k'>Next action</div><p>"+next+"</p>",n++)}
     </div>
     <div class="bento">
-      ${tile("c6","<div class='k'>Definition of Done</div><ul class='checklist'>"+PROJECT.dod.map((d,k)=>`<li><span class='ix'>${pad2(k+1)}</span>${esc(d.text)}</li>`).join("")+"</ul>",n++)}
+      ${tile("c6","<div class='k'>Mission track</div>"+missionTrack(),n++)}
+    </div>
+    <div class="bento">
+      ${tile("c3","<div class='k'>Task burn · by phase</div>"+taskBurn(),n++)}
+      ${tile("c3","<div class='k'>Definition of Done</div><ul class='checklist'>"+PROJECT.dod.map((d,k)=>`<li><span class='ix'>${pad2(k+1)}</span>${esc(d.text)}</li>`).join("")+"</ul>",n++)}
     </div>`;
   return v;
 }
@@ -484,9 +727,9 @@ function viewStack(){
     <div class="vhead"><div class="eye">Technology Stack</div><h1>Stack</h1>
       <p class="lead">Versions current as of ${esc(PROJECT.meta.generated)}. Each row notes its source — verified from <code>package.json</code>, confirmed via MCP, or flagged for manual checking.</p></div>
     <div class="bento">
-      ${tile("stat c2 accent","<span class='num'>"+PROJECT.stack.length+"</span><span class='lbl'>Technologies</span>",n++)}
-      ${tile("stat c2","<span class='num'>"+layers.size+"</span><span class='lbl'>Layers</span>",n++)}
-      ${tile("stat c2","<span class='num'>"+verified+"</span><span class='lbl'>Version-verified</span>",n++)}
+      ${tile("stat c2 accent","<span class='num' data-count='"+PROJECT.stack.length+"'>0</span><span class='lbl'>Technologies</span>",n++)}
+      ${tile("stat c2","<span class='num' data-count='"+layers.size+"'>0</span><span class='lbl'>Layers</span>",n++)}
+      ${tile("stat c2","<span class='num' data-count='"+verified+"'>0</span><span class='lbl'>Version-verified</span>",n++)}
       ${tile("c6","<div class='k'>Stack table</div><table><thead><tr><th>Layer</th><th>Tech</th><th>Version</th><th>Source</th><th>Purpose</th></tr></thead><tbody>"+
         PROJECT.stack.map(r=>`<tr><td>${esc(r[0])}</td><td><strong>${esc(r[1])}</strong></td><td class='mono'>${esc(r[2])}</td><td>${srcBadge(r[3])}</td><td>${esc(r[4])}</td></tr>`).join("")+"</tbody></table>",n++)}
     </div>`;
@@ -497,7 +740,7 @@ function viewPhase(p){
   const v=document.createElement("div"); v.className="view"; v.id="view-phase-"+p.n;
   const st = p.status==="specced"?"Specced":p.status==="complete"?"Complete":"Roadmap only";
   const isActive = p.n===(activePhase()||{}).n;
-  const head = `<div class="vhead"><span class="phase-numeral">${pad2(p.n)}</span><div class="eye">Phase ${p.n}</div><h1>${esc(p.name)}</h1>
+  const head = `<div class="vhead"><span class="phase-numeral" aria-hidden="true">${pad2(p.n)}</span><div class="eye">Phase ${p.n}</div><h1>${esc(p.name)}</h1>
     <p class="lead">${esc(p.description)}</p>
     <div class="badges">${isActive?'<span class="bdg active">active</span>':''}<span class="bdg ${p.priority}">${esc(p.priority)} priority</span><span class="bdg ${p.status}">${st}</span></div></div>`;
 
@@ -510,9 +753,9 @@ function viewPhase(p){
   const done = p.tasks.filter(t=>t.done).length;
   v.innerHTML = head + `
     <div class="tabs" data-phase="${p.n}">
-      <button class="tab on" data-t="spec">Spec</button>
-      <button class="tab" data-t="design">Design</button>
-      <button class="tab" data-t="tasks">Tasks <span class="c">${done}/${p.tasks.length}</span></button>
+      <button class="tab on" data-t="spec">spec</button>
+      <button class="tab" data-t="design">design</button>
+      <button class="tab" data-t="tasks">tasks <span class="c">${done}/${p.tasks.length}</span></button>
     </div>
     <div class="panel on" data-p="spec">${specPanel(p)}</div>
     <div class="panel" data-p="design">${designPanel(p)}</div>
@@ -576,7 +819,9 @@ function tasksPanel(p){
     </svg><div class="ring-pct">${pct}%</div></div>`;
   const cols = groups.map(g=>{
     const gt=p.tasks.filter(t=>t.group===g);
-    return `<div class="kcol"><h3>${esc(g)}<span class="kc">${gt.filter(t=>t.done).length}/${gt.length}</span></h3>
+    const gd=gt.filter(t=>t.done).length, gp=gt.length?Math.round(gd/gt.length*100):0;
+    return `<div class="kcol"><h3>${esc(g)}<span class="kc">${gd}/${gt.length}</span></h3>
+      <div class="kprog"><span data-w="${gp}"></span></div>
       ${gt.map(t=>`<div class="kcard ${t.done?'done':''}" data-task="${esc(t.id)}">
         <div class="top"><span class="ck"></span><span class="id">${esc(t.id)}</span><span class="tx">${esc(t.text)}</span>${t.detail?'<span class="cv">▸</span>':''}</div>
         ${t.detail?`<div class="det">${esc(t.detail)}</div>`:''}</div>`).join("")}</div>`;
@@ -587,30 +832,144 @@ function tasksPanel(p){
     <div class="kanban">${cols}</div>`;
 }
 
+/* ═══ Navigation, palette, keys, glow ═══ */
+const viewOrder = [];
+function goView(id){
+  document.querySelectorAll(".nav").forEach(x=>x.classList.toggle("on", x.dataset.v===id));
+  document.querySelectorAll(".view").forEach(x=>x.classList.remove("on"));
+  const view=$("#view-"+id);
+  if(view){ view.classList.add("on"); $("#main").scrollTop=0; animateBars(view); }
+}
+
+/* width-animated bars start at 0 — fire them when their view shows */
+function animateBars(scope){
+  scope.querySelectorAll("[data-w]").forEach(el=>{ el.style.width=el.dataset.w+"%"; });
+}
+
+function countUp(el){
+  const target=+el.dataset.count;
+  if(REDUCED||!target){ el.textContent=target; return; }
+  const dur=750, t0=performance.now();
+  (function frame(now){
+    const p=Math.min(1,(now-t0)/dur);
+    el.textContent=Math.round(target*(1-Math.pow(1-p,3)));
+    if(p<1) requestAnimationFrame(frame);
+  })(t0);
+}
+
 function wire(){
   $("#sb").addEventListener("click", e=>{
-    const it=e.target.closest(".nav"); if(!it) return;
-    document.querySelectorAll(".nav").forEach(x=>x.classList.remove("on"));
-    it.classList.add("on");
-    document.querySelectorAll(".view").forEach(x=>x.classList.remove("on"));
-    const view=$("#view-"+it.dataset.v); if(view){ view.classList.add("on"); $("#main").scrollTop=0; }
+    const it=e.target.closest(".nav"); if(!it) return; goView(it.dataset.v);
   });
   $("#main").addEventListener("click", e=>{
+    const tn=e.target.closest(".tnode");
+    if(tn){ goView(tn.dataset.v); return; }
     const tab=e.target.closest(".tab");
     if(tab){ const tabs=tab.closest(".tabs"), view=tab.closest(".view");
       tabs.querySelectorAll(".tab").forEach(t=>t.classList.remove("on")); tab.classList.add("on");
       view.querySelectorAll(".panel").forEach(pl=>pl.classList.remove("on"));
-      view.querySelector(`[data-p="${tab.dataset.t}"]`).classList.add("on"); return; }
+      const panel=view.querySelector(`[data-p="${tab.dataset.t}"]`); panel.classList.add("on"); animateBars(panel); return; }
     const top=e.target.closest(".kcard .top");
     if(top){ const c=top.closest(".kcard"); if(c.querySelector(".det")) c.classList.toggle("open"); }
   });
+
+  /* pointer-tracking glow */
+  document.addEventListener("pointermove", e=>{
+    const t=e.target.closest(".tile"); if(!t) return;
+    const r=t.getBoundingClientRect();
+    t.style.setProperty("--mx",(e.clientX-r.left)+"px");
+    t.style.setProperty("--my",(e.clientY-r.top)+"px");
+  }, {passive:true});
+
+  /* ⌘K palette */
+  const pal=$("#pal"), palIn=$("#palIn"), palLs=$("#palLs");
+  let palItems=[], palSel=0;
+  function palOpen(){ pal.hidden=false; palIn.value=""; palFill(""); palIn.focus(); }
+  function palClose(){ pal.hidden=true; }
+  function palFill(q){
+    const ql=q.trim().toLowerCase();
+    palItems=viewOrder.filter(it=>!ql||it.label.toLowerCase().includes(ql));
+    palSel=0;
+    palLs.innerHTML=palItems.map((it,i)=>`<li class="${i===palSel?'sel':''}" data-i="${i}">
+      <span class="pd ${it.dot||''}"></span>${esc(it.label)}<span class="pk"><kbd>${i+1<10?i+1:''}</kbd></span></li>`).join("")
+      ||`<li style="color:var(--text-dim)">no match — try a phase name</li>`;
+  }
+  function palGo(){ const it=palItems[palSel]; if(it){ palClose(); goView(it.v); } }
+  $("#palBtn").addEventListener("click", palOpen);
+  pal.addEventListener("click", e=>{ if(e.target===pal) palClose();
+    const li=e.target.closest("li[data-i]"); if(li){ palSel=+li.dataset.i; palGo(); } });
+  palIn.addEventListener("input", ()=>palFill(palIn.value));
+  palIn.addEventListener("keydown", e=>{
+    if(e.key==="ArrowDown"){ e.preventDefault(); palSel=Math.min(palSel+1,palItems.length-1); }
+    else if(e.key==="ArrowUp"){ e.preventDefault(); palSel=Math.max(palSel-1,0); }
+    else if(e.key==="Enter"){ e.preventDefault(); palGo(); return; }
+    else if(e.key==="Escape"){ palClose(); return; }
+    else return;
+    palLs.querySelectorAll("li").forEach((li,i)=>li.classList.toggle("sel",i===palSel));
+  });
+
+  /* global keys: ⌘K / ctrl+K / "/" open palette · digits jump · [ ] cycle */
+  document.addEventListener("keydown", e=>{
+    if((e.metaKey||e.ctrlKey)&&e.key.toLowerCase()==="k"){ e.preventDefault(); pal.hidden?palOpen():palClose(); return; }
+    if(!pal.hidden) return;
+    if(e.target.closest("input,textarea")) return;
+    if(e.key==="/"){ e.preventDefault(); palOpen(); return; }
+    if(e.key==="Escape"){ palClose(); return; }
+    const cur=viewOrder.findIndex(it=>$("#view-"+it.v).classList.contains("on"));
+    if(/^[1-9]$/.test(e.key)){ const it=viewOrder[+e.key-1]; if(it) goView(it.v); return; }
+    if(e.key==="]"){ goView(viewOrder[(cur+1)%viewOrder.length].v); return; }
+    if(e.key==="["){ goView(viewOrder[(cur-1+viewOrder.length)%viewOrder.length].v); return; }
+  });
+}
+
+/* ═══ Boot sequence ═══ */
+function boot(){
+  const bootEl=$("#boot");
+  const dismiss=()=>{
+    if(document.body.classList.contains("booted")) return;
+    document.body.classList.add("booted");
+    bootEl.classList.add("off");
+    document.querySelectorAll(".view.on [data-w]").forEach(el=>{ el.style.width=el.dataset.w+"%"; });
+    document.querySelectorAll(".num[data-count]").forEach(countUp);
+    setTimeout(()=>bootEl.remove(), 700);
+  };
+  if(REDUCED||location.hash==="#noboot"||!PROJECT){ dismiss(); return; }
+  const m=PROJECT.meta, {d,t}=taskTotals();
+  const lines=[
+    {tx:`$ own status --dashboard`, cls:"cmd"},
+    {tx:`▸ reading dashboard-data.js ......... ok`},
+    {tx:`▸ project: ${m.name} · phases: ${PROJECT.phases.length} · tasks: ${d}/${t}`},
+    {tx:`▸ compositing terminal-futurism ..... ok`},
+    {tx:`$ welcome back. own your code.`, cls:"cmd", caret:true},
+  ];
+  const body=$("#bootBody");
+  let delay=0.15;
+  lines.forEach(L=>{
+    const div=document.createElement("div");
+    div.className="bline"+(L.cls?" "+L.cls:"");
+    div.style.setProperty("--ch", L.tx.length);
+    div.style.setProperty("--d", delay+"s");
+    div.innerHTML=esc(L.tx).replace(/ ok$/," <span class='ok-tag'>ok</span>")+(L.caret?' <span class="bcaret"></span>':"");
+    body.appendChild(div);
+    delay+=0.3;
+  });
+  const auto=setTimeout(dismiss, delay*1000+550);
+  const skip=()=>{ clearTimeout(auto); dismiss(); window.removeEventListener("keydown",skip); window.removeEventListener("pointerdown",skip); };
+  window.addEventListener("keydown", skip, {once:true});
+  window.addEventListener("pointerdown", skip, {once:true});
 }
 
 /* Boot — guard against a missing/failed data file */
 if (!PROJECT) {
   $("#main").innerHTML = '<div class="note">⚠️ <strong>dashboard-data.js</strong> didn\'t load. It must sit next to dashboard.html. The /own:* commands keep it in sync.</div>';
+  document.body.classList.add("booted"); $("#boot").remove();
 } else {
-  renderHeader(); renderSidebar(); renderViews(); wire();
+  renderHeader(); renderSidebar(); renderTmux(); renderViews();
+  /* palette + shortcut order: overview, stack, then phases */
+  viewOrder.push({label:"Overview", v:"overview", dot:"specced"});
+  viewOrder.push({label:"Stack", v:"stack", dot:"specced"});
+  PROJECT.phases.forEach(p=>viewOrder.push({label:`Phase ${p.n} — ${p.name}`, v:"phase-"+p.n, dot:p.status==="complete"?"complete":p.status==="specced"?"specced":""}));
+  wire(); boot();
 }
 </script>
 </body>

--- a/scripts/base-install.ps1
+++ b/scripts/base-install.ps1
@@ -1,4 +1,4 @@
-# OwnYourCode Base Installation Script (Windows)
+﻿# OwnYourCode Base Installation Script (Windows)
 # AI-Mentored Development for All Developers
 # Version 2.6.0 - Dashboard Elevated
 #

--- a/scripts/base-install.ps1
+++ b/scripts/base-install.ps1
@@ -1,4 +1,4 @@
-﻿# OwnYourCode Base Installation Script (Windows)
+# OwnYourCode Base Installation Script (Windows)
 # AI-Mentored Development for All Developers
 # Version 2.6.0 - Dashboard Elevated
 #
@@ -19,10 +19,10 @@ function Write-Err { param($msg) Write-Host "[ERROR] $msg" -ForegroundColor Red;
 
 # Header
 Write-Host ""
-Write-Host "╔═══════════════════════════════════════════════════════╗" -ForegroundColor Green
-Write-Host "║         OwnYourCode Installation v2.6.0               ║" -ForegroundColor Green
-Write-Host "║   AI-Mentored Development with Profile Support        ║" -ForegroundColor Green
-Write-Host "╚═══════════════════════════════════════════════════════╝" -ForegroundColor Green
+Write-Host "+=======================================================+" -ForegroundColor Green
+Write-Host "|         OwnYourCode Installation v2.6.0               |" -ForegroundColor Green
+Write-Host "|   AI-Mentored Development with Profile Support        |" -ForegroundColor Green
+Write-Host "+=======================================================+" -ForegroundColor Green
 Write-Host ""
 
 # ============================================================================
@@ -156,9 +156,9 @@ if (-not (Test-Path $registryPath)) {
 # ============================================================================
 
 Write-Host ""
-Write-Host "╔═══════════════════════════════════════════════════════╗" -ForegroundColor Green
-Write-Host "║          Installation Complete!                       ║" -ForegroundColor Green
-Write-Host "╚═══════════════════════════════════════════════════════╝" -ForegroundColor Green
+Write-Host "+=======================================================+" -ForegroundColor Green
+Write-Host "|          Installation Complete!                       |" -ForegroundColor Green
+Write-Host "+=======================================================+" -ForegroundColor Green
 Write-Host ""
 
 Write-OK "OwnYourCode installed to ~/ownyourcode/"

--- a/scripts/base-install.ps1
+++ b/scripts/base-install.ps1
@@ -1,6 +1,6 @@
 # OwnYourCode Base Installation Script (Windows)
 # AI-Mentored Development for All Developers
-# Version 2.5.0 - Dashboard SDD
+# Version 2.6.0 - Dashboard Elevated
 #
 # Usage: irm https://raw.githubusercontent.com/DanielPodolsky/ownyourcode/main/scripts/base-install.ps1 | iex
 
@@ -20,7 +20,7 @@ function Write-Err { param($msg) Write-Host "[ERROR] $msg" -ForegroundColor Red;
 # Header
 Write-Host ""
 Write-Host "╔═══════════════════════════════════════════════════════╗" -ForegroundColor Green
-Write-Host "║         OwnYourCode Installation v2.5.0               ║" -ForegroundColor Green
+Write-Host "║         OwnYourCode Installation v2.6.0               ║" -ForegroundColor Green
 Write-Host "║   AI-Mentored Development with Profile Support        ║" -ForegroundColor Green
 Write-Host "╚═══════════════════════════════════════════════════════╝" -ForegroundColor Green
 Write-Host ""

--- a/scripts/base-install.sh
+++ b/scripts/base-install.sh
@@ -2,7 +2,7 @@
 
 # OwnYourCode Base Installation Script
 # AI-Mentored Development for All Developers
-# Version 2.5.0 - Dashboard SDD
+# Version 2.6.0 - Dashboard Elevated
 #
 # Usage: curl -sSL https://raw.githubusercontent.com/DanielPodolsky/ownyourcode/main/scripts/base-install.sh | bash
 
@@ -28,7 +28,7 @@ error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
 # Header
 echo ""
 echo -e "${GREEN}╔═══════════════════════════════════════════════════════╗${NC}"
-echo -e "${GREEN}║         OwnYourCode Installation v2.5.0               ║${NC}"
+echo -e "${GREEN}║         OwnYourCode Installation v2.6.0               ║${NC}"
 echo -e "${GREEN}║   AI-Mentored Development with Profile Support        ║${NC}"
 echo -e "${GREEN}╚═══════════════════════════════════════════════════════╝${NC}"
 echo ""

--- a/scripts/project-install.ps1
+++ b/scripts/project-install.ps1
@@ -1,4 +1,4 @@
-﻿# OwnYourCode Project Installation Script (Windows)
+# OwnYourCode Project Installation Script (Windows)
 # AI-Mentored Development for All Developers
 # Version 2.6.0 - Dashboard Elevated
 
@@ -17,10 +17,10 @@ function Write-Err { param($msg) Write-Host "[ERROR] $msg" -ForegroundColor Red;
 
 # Header
 Write-Host ""
-Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Green
-Write-Host "║            OwnYourCode Installation v2.6.0                ║" -ForegroundColor Green
-Write-Host "║    AI-Mentored Development with Profile Support           ║" -ForegroundColor Green
-Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Green
+Write-Host "+===========================================================+" -ForegroundColor Green
+Write-Host "|            OwnYourCode Installation v2.6.0                |" -ForegroundColor Green
+Write-Host "|    AI-Mentored Development with Profile Support           |" -ForegroundColor Green
+Write-Host "+===========================================================+" -ForegroundColor Green
 Write-Host ""
 
 # Check base exists
@@ -54,7 +54,7 @@ if (Test-Path $ownyourcodeDir) {
 Write-Info "Creating directories..."
 
 $directories = @(
-    # Note: v2.5 drops product/ — mission/stack/roadmap now live in the dashboard.
+    # Note: v2.5 drops product/ - mission/stack/roadmap now live in the dashboard.
     "ownyourcode/specs/active",
     "ownyourcode/specs/completed",
     "ownyourcode/career/stories",
@@ -129,7 +129,7 @@ if (Test-Path $CLAUDE_MD) {
 
         if (($replace -eq "y" -or $replace -eq "Y") -and (Test-Path $TEMPLATE)) {
             # Remove existing section and append fresh
-            $cleaned = $content -replace "# ═.*OWNYOURCODE[\s\S]*?# ═.*END OWNYOURCODE[^\n]*", ""
+            $cleaned = $content -replace "# \u2550.*OWNYOURCODE[\s\S]*?# \u2550.*END OWNYOURCODE[^\n]*", ""
             $templateContent = Get-Content $TEMPLATE -Raw
             Set-Content -Path $CLAUDE_MD -Value ($cleaned.Trim() + "`n`n" + $templateContent)
             Write-OK "OwnYourCode section replaced"
@@ -284,7 +284,7 @@ if (Test-Path $srcGuides) {
 }
 
 # ============================================================================
-# STEP 7.5: Seed the dashboard (v2.5 — Dashboard SDD)
+# STEP 7.5: Seed the dashboard (v2.5 - Dashboard SDD)
 # ============================================================================
 # v2.5 replaces the per-page product/*.html and specs/**/*.html files with a
 # single dashboard: a stable view shell (dashboard.html) + a data file
@@ -328,9 +328,9 @@ if (Test-Path $dashTemplate) {
         Copy-Item $promptSrc -Destination (Join-Path $PROJECT_DIR "ownyourcode/.theme/theme-prompt.md") -Force
     }
 
-    Write-OK "Dashboard seeded — open ownyourcode/dashboard/dashboard.html, then run /own:init"
+    Write-OK "Dashboard seeded - open ownyourcode/dashboard/dashboard.html, then run /own:init"
 } else {
-    Write-Warn "Dashboard templates not found in source repo — skipping dashboard seed."
+    Write-Warn "Dashboard templates not found in source repo - skipping dashboard seed."
     Write-Warn "Update your OwnYourCode base install to get the v2.5 dashboard."
 }
 
@@ -441,9 +441,9 @@ Write-OK "Manifest created at .claude/ownyourcode-manifest.json"
 # ============================================================================
 
 Write-Host ""
-Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Green
-Write-Host "║          Installation Complete! v2.6.0                    ║" -ForegroundColor Green
-Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Green
+Write-Host "+===========================================================+" -ForegroundColor Green
+Write-Host "|          Installation Complete! v2.6.0                    |" -ForegroundColor Green
+Write-Host "+===========================================================+" -ForegroundColor Green
 Write-Host ""
 
 Write-OK "OwnYourCode v2.6.0 installed successfully!"

--- a/scripts/project-install.ps1
+++ b/scripts/project-install.ps1
@@ -1,4 +1,4 @@
-# OwnYourCode Project Installation Script (Windows)
+﻿# OwnYourCode Project Installation Script (Windows)
 # AI-Mentored Development for All Developers
 # Version 2.6.0 - Dashboard Elevated
 

--- a/scripts/project-install.ps1
+++ b/scripts/project-install.ps1
@@ -1,6 +1,6 @@
 # OwnYourCode Project Installation Script (Windows)
 # AI-Mentored Development for All Developers
-# Version 2.5.0 - Dashboard SDD
+# Version 2.6.0 - Dashboard Elevated
 
 $ErrorActionPreference = "Stop"
 
@@ -18,7 +18,7 @@ function Write-Err { param($msg) Write-Host "[ERROR] $msg" -ForegroundColor Red;
 # Header
 Write-Host ""
 Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Green
-Write-Host "║            OwnYourCode Installation v2.5.0                ║" -ForegroundColor Green
+Write-Host "║            OwnYourCode Installation v2.6.0                ║" -ForegroundColor Green
 Write-Host "║    AI-Mentored Development with Profile Support           ║" -ForegroundColor Green
 Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Green
 Write-Host ""
@@ -367,7 +367,7 @@ $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 
 $manifestContent = @"
 {
-  "version": "2.5.0",
+  "version": "2.6.0",
   "installed_at": "$timestamp",
   "claude_md_location": "$CLAUDE_MD_REL",
   "backup_path": $backupJson,
@@ -442,11 +442,11 @@ Write-OK "Manifest created at .claude/ownyourcode-manifest.json"
 
 Write-Host ""
 Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Green
-Write-Host "║          Installation Complete! v2.5.0                    ║" -ForegroundColor Green
+Write-Host "║          Installation Complete! v2.6.0                    ║" -ForegroundColor Green
 Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Green
 Write-Host ""
 
-Write-OK "OwnYourCode v2.5.0 installed successfully!"
+Write-OK "OwnYourCode v2.6.0 installed successfully!"
 Write-Host ""
 
 Write-Info "What was created:"

--- a/scripts/project-install.sh
+++ b/scripts/project-install.sh
@@ -2,7 +2,7 @@
 
 # OwnYourCode Project Installation Script
 # AI-Mentored Development for All Developers
-# Version 2.5.0 - Dashboard SDD
+# Version 2.6.0 - Dashboard Elevated
 
 set -e
 
@@ -29,7 +29,7 @@ error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
 # Header
 echo ""
 echo -e "${GREEN}╔═══════════════════════════════════════════════════════════╗${NC}"
-echo -e "${GREEN}║            OwnYourCode Installation v2.5.0                 ║${NC}"
+echo -e "${GREEN}║            OwnYourCode Installation v2.6.0                 ║${NC}"
 echo -e "${GREEN}║    AI-Mentored Development with Profile Support            ║${NC}"
 echo -e "${GREEN}╚═══════════════════════════════════════════════════════════╝${NC}"
 echo ""
@@ -325,7 +325,7 @@ fi
 
 cat > "$MANIFEST" << EOF
 {
-  "version": "2.5.0",
+  "version": "2.6.0",
   "installed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "claude_md_location": "$CLAUDE_MD_REL",
   "backup_path": $BACKUP_JSON,
@@ -399,11 +399,11 @@ success "Manifest created at .claude/ownyourcode-manifest.json"
 
 echo ""
 echo -e "${GREEN}╔═══════════════════════════════════════════════════════════╗${NC}"
-echo -e "${GREEN}║          Installation Complete! v2.5.0                    ║${NC}"
+echo -e "${GREEN}║          Installation Complete! v2.6.0                    ║${NC}"
 echo -e "${GREEN}╚═══════════════════════════════════════════════════════════╝${NC}"
 echo ""
 
-success "OwnYourCode v2.5.0 installed successfully!"
+success "OwnYourCode v2.6.0 installed successfully!"
 echo ""
 
 info "What was created:"

--- a/scripts/project-uninstall.ps1
+++ b/scripts/project-uninstall.ps1
@@ -1,4 +1,4 @@
-﻿# OwnYourCode Project Uninstallation Script (Windows)
+# OwnYourCode Project Uninstallation Script (Windows)
 # Cleanly removes OwnYourCode from a project
 
 $ErrorActionPreference = "Stop"
@@ -52,9 +52,9 @@ function Write-Err { param($msg) Write-Host "[ERROR] $msg" -ForegroundColor Red;
 
 # Header
 Write-Host ""
-Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Red
-Write-Host "║            OwnYourCode Uninstallation                     ║" -ForegroundColor Red
-Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Red
+Write-Host "+===========================================================+" -ForegroundColor Red
+Write-Host "|            OwnYourCode Uninstallation                     |" -ForegroundColor Red
+Write-Host "+===========================================================+" -ForegroundColor Red
 Write-Host ""
 
 # ============================================================================
@@ -112,7 +112,7 @@ if (Test-Path $CLAUDE_MD) {
     } elseif ((Get-Content $CLAUDE_MD -Raw) -match "OWNYOURCODE:") {
         # Legacy fallback - remove OwnYourCode section using regex
         $content = Get-Content $CLAUDE_MD -Raw
-        $cleaned = $content -replace "# ═.*OWNYOURCODE[\s\S]*?# ═.*END OWNYOURCODE[^\n]*\n?", ""
+        $cleaned = $content -replace "# \u2550.*OWNYOURCODE[\s\S]*?# \u2550.*END OWNYOURCODE[^\n]*\n?", ""
         $cleaned = $cleaned.Trim()
 
         if ([string]::IsNullOrWhiteSpace($cleaned)) {
@@ -225,9 +225,9 @@ if (Test-Path $ownyourcodeDir) {
 # ============================================================================
 
 Write-Host ""
-Write-Host "╔═══════════════════════════════════════════════════════════╗" -ForegroundColor Green
-Write-Host "║          Uninstallation Complete!                         ║" -ForegroundColor Green
-Write-Host "╚═══════════════════════════════════════════════════════════╝" -ForegroundColor Green
+Write-Host "+===========================================================+" -ForegroundColor Green
+Write-Host "|          Uninstallation Complete!                         |" -ForegroundColor Green
+Write-Host "+===========================================================+" -ForegroundColor Green
 Write-Host ""
 
 Write-OK "OwnYourCode has been removed from this project."

--- a/scripts/project-uninstall.ps1
+++ b/scripts/project-uninstall.ps1
@@ -1,4 +1,4 @@
-# OwnYourCode Project Uninstallation Script (Windows)
+﻿# OwnYourCode Project Uninstallation Script (Windows)
 # Cleanly removes OwnYourCode from a project
 
 $ErrorActionPreference = "Stop"

--- a/tests/commands.test.sh
+++ b/tests/commands.test.sh
@@ -66,6 +66,19 @@ present_in 'class="tmx"'       "$TPL/dashboard.html.template" "template has the 
 present_in 'id="pal"'          "$TPL/dashboard.html.template" "template has the v2.6 command palette"
 present_in 'Terminal-Futurism' "$TPL/theme-prompt.md.template" "default theme brief describes Terminal-Futurism"
 
+echo "— Windows PowerShell 5.1 compatibility (BOM) —"
+# PS 5.1 reads BOM-less scripts as ANSI; our .ps1 files contain Unicode banner
+# art whose mojibake includes curly quotes that PS treats as string delimiters
+# → cascade parse errors. UTF-8 BOM is the documented fix. (Found live on a
+# real Windows machine, 2026-06-11.)
+for f in "$ROOT"/scripts/*.ps1; do
+  if [ "$(head -c 3 "$f" | od -An -tx1 | tr -d ' \n')" = "efbbbf" ]; then
+    ok "$(basename "$f") has UTF-8 BOM (PS 5.1 safe)"
+  else
+    bad "$(basename "$f") missing UTF-8 BOM — Windows PowerShell 5.1 misparses its Unicode"
+  fi
+done
+
 echo "— every shipped command is documented in CLAUDE.md.template —"
 for f in "$CMD"/*.md; do
   cmd_name="$(basename "$f" .md)"

--- a/tests/commands.test.sh
+++ b/tests/commands.test.sh
@@ -66,6 +66,12 @@ present_in 'class="tmx"'       "$TPL/dashboard.html.template" "template has the 
 present_in 'id="pal"'          "$TPL/dashboard.html.template" "template has the v2.6 command palette"
 present_in 'Terminal-Futurism' "$TPL/theme-prompt.md.template" "default theme brief describes Terminal-Futurism"
 
+echo "— every shipped command is documented in CLAUDE.md.template —"
+for f in "$CMD"/*.md; do
+  cmd_name="$(basename "$f" .md)"
+  present_in "/own:$cmd_name" "$ROOT/core/CLAUDE.md.template" "CLAUDE.md.template lists /own:$cmd_name"
+done
+
 echo ""
 echo "commands: ${PASS}/$((PASS+FAIL)) passed"
 [ "$FAIL" -eq 0 ]

--- a/tests/commands.test.sh
+++ b/tests/commands.test.sh
@@ -66,16 +66,19 @@ present_in 'class="tmx"'       "$TPL/dashboard.html.template" "template has the 
 present_in 'id="pal"'          "$TPL/dashboard.html.template" "template has the v2.6 command palette"
 present_in 'Terminal-Futurism' "$TPL/theme-prompt.md.template" "default theme brief describes Terminal-Futurism"
 
-echo "— Windows PowerShell 5.1 compatibility (BOM) —"
-# PS 5.1 reads BOM-less scripts as ANSI; our .ps1 files contain Unicode banner
-# art whose mojibake includes curly quotes that PS treats as string delimiters
-# → cascade parse errors. UTF-8 BOM is the documented fix. (Found live on a
-# real Windows machine, 2026-06-11.)
+echo "— Windows PowerShell 5.1 compatibility (pure-ASCII .ps1) —"
+# PS 5.1 reads BOM-less script FILES as ANSI, so non-ASCII content (banner
+# art) decodes to mojibake containing curly quotes that PS treats as string
+# delimiters -> cascade parse errors (found live on Windows, 2026-06-11).
+# Convention (same as Chocolatey/Scoop installers): .ps1 files are pure
+# ASCII, which behaves identically on PS 5.1/7, -File, and irm|iex — no BOM
+# ambiguity on any path. Unicode in match patterns goes via \uXXXX escapes.
 for f in "$ROOT"/scripts/*.ps1; do
-  if [ "$(head -c 3 "$f" | od -An -tx1 | tr -d ' \n')" = "efbbbf" ]; then
-    ok "$(basename "$f") has UTF-8 BOM (PS 5.1 safe)"
+  nonascii="$(LC_ALL=C tr -d '\11\12\15\40-\176' < "$f" | wc -c | tr -d ' ')"
+  if [ "$nonascii" = "0" ]; then
+    ok "$(basename "$f") is pure ASCII (PS 5.1 safe on every invocation path)"
   else
-    bad "$(basename "$f") missing UTF-8 BOM — Windows PowerShell 5.1 misparses its Unicode"
+    bad "$(basename "$f") has $nonascii non-ASCII bytes — PS 5.1 will misparse it when run as a file"
   fi
 done
 

--- a/tests/commands.test.sh
+++ b/tests/commands.test.sh
@@ -62,6 +62,8 @@ present_in 'Terminal-Futurism' "$TPL/dashboard.html.template" "template names Te
 present_in '#22c55e'           "$TPL/dashboard.html.template" "template uses the green accent"
 present_in 'JetBrains\+Mono'   "$TPL/dashboard.html.template" "template loads JetBrains Mono"
 present_in 'phase-numeral'     "$TPL/dashboard.html.template" "template has the ghost-numeral motif"
+present_in 'class="tmx"'       "$TPL/dashboard.html.template" "template has the v2.6 tmux status bar"
+present_in 'id="pal"'          "$TPL/dashboard.html.template" "template has the v2.6 command palette"
 present_in 'Terminal-Futurism' "$TPL/theme-prompt.md.template" "default theme brief describes Terminal-Futurism"
 
 echo ""

--- a/tests/dashboard-render.test.js
+++ b/tests/dashboard-render.test.js
@@ -13,6 +13,10 @@
    window.PROJECT) then eval the template's inline <script> (which boots and
    renders), and assert on the captured output. This mirrors how the browser
    loads the page (data via window.PROJECT, then the render script runs).
+
+   v2.6 notes: the elevated shell also uses matchMedia / location / timers /
+   rAF / navigator-guarded labels — stubbed below. matchMedia reports
+   prefers-reduced-motion so the boot sequence resolves synchronously.
    ════════════════════════════════════════════════════════════════════ */
 const fs = require("fs");
 const path = require("path");
@@ -25,7 +29,7 @@ const cap = []; // every DOM write, flattened to strings, for assertions
 
 function makeEl() {
   return {
-    dataset: {}, style: {}, hidden: false,
+    dataset: {}, style: { setProperty() {} }, hidden: false,
     set innerHTML(v) { this._h = v; cap.push(v); },
     get innerHTML() { return this._h || ""; },
     set className(v) { this._c = v; cap.push("CLASS:" + v); },
@@ -33,8 +37,8 @@ function makeEl() {
     set textContent(v) { this._t = v; cap.push("TEXT:" + v); },
     get textContent() { return this._t || ""; },
     appendChild(c) { if (c && c._h) cap.push(c._h); },
-    addEventListener() {},
-    classList: { add() {}, remove() {}, toggle() {} },
+    addEventListener() {}, removeEventListener() {}, remove() {}, focus() {},
+    classList: { add() {}, remove() {}, toggle() {}, contains() { return false; } },
     querySelector() { return makeEl(); },
     querySelectorAll() { return []; },
     closest() { return null; },
@@ -45,11 +49,20 @@ global.document = {
   _title: "",
   set title(v) { this._title = v; },
   get title() { return this._title; },
+  body: makeEl(),
   querySelector() { return makeEl(); },
   querySelectorAll() { return []; },
   createElement() { return makeEl(); },
+  addEventListener() {},
 };
-global.window = {};
+global.window = { addEventListener() {}, removeEventListener() {} };
+global.matchMedia = () => ({ matches: true }); // reduced motion → boot skips
+global.location = { hash: "" };
+global.performance = { now: () => 0 };
+global.requestAnimationFrame = () => {};
+global.setInterval = () => 0;   // tmux clock — don't keep node alive
+global.setTimeout = () => 0;    // boot auto-dismiss — never fires here
+global.clearTimeout = () => {};
 
 // 1) load the fixture → sets window.PROJECT (mirrors <script src="dashboard-data.js">)
 eval(fs.readFileSync(FIXTURE, "utf8"));
@@ -61,6 +74,9 @@ if (!scripts.length) { console.error("✗ no inline <script> found in template")
 eval(scripts.join("\n;\n"));
 
 const all = cap.join("\n");
+// the stub captures each view twice (innerHTML set + appendChild) — exact
+// counts must run against a single capture of the overview view
+const overview = cap.find(s => typeof s === "string" && s.includes("Mission track")) || "";
 
 // 3) assertions — one per schema feature the dashboard must render
 const checks = [
@@ -82,9 +98,9 @@ const checks = [
   ["roadmap-only phase dot",              () => all.includes('class="d roadmap-only"')],
   ["active-phase highlight applied",      () => all.includes("CLASS:nav active-phase")],
   ["active 'Active' tag",                 () => all.includes('class="atag">Active')],
-  // signature motif
-  ["ghost numeral on phase header (01)",  () => all.includes('class="phase-numeral">01')],
-  ["ghost numeral 02",                    () => all.includes('class="phase-numeral">02')],
+  // signature motif (v2.6 numerals carry aria-hidden)
+  ["ghost numeral on phase header (01)",  () => /class="phase-numeral"[^>]*>01</.test(all)],
+  ["ghost numeral 02",                    () => /class="phase-numeral"[^>]*>02</.test(all)],
   // specced phase tabs + content
   ["Spec/Design/Tasks tabs render",       () => all.includes('data-t="spec"') && all.includes('data-t="design"') && all.includes('data-t="tasks"')],
   ["user story renders",                  () => all.includes("returning user")],
@@ -106,6 +122,21 @@ const checks = [
   // roadmap-only phase
   ["roadmap-only planned scope",          () => all.includes("Calendar heatmap")],
   ["roadmap-only 'not specced yet' note", () => all.includes("isn't specced yet")],
+  // ── v2.6 elevations ──────────────────────────────────────────────
+  ["mission track renders all 4 nodes",   () => (overview.match(/class="tnode /g) || []).length === 4],
+  ["mission track marks active phase",    () => all.includes('class="tnode active"')],
+  ["mission track marks complete phase",  () => all.includes('class="tnode complete"')],
+  ["track progress line carries width",   () => /track-line[\s\S]*?data-w="/.test(all)],
+  ["task burn: one row per phase",        () => (overview.match(/class="row( hollow)?"/g) || []).length === 4],
+  ["task burn: roadmap rows hollow",      () => (overview.match(/class="row hollow"/g) || []).length === 2],
+  ["tmux bar: brand + phase + tasks",     () => all.includes("OWN v") && all.includes("phase 2/4") && all.includes("tasks <b>5/9</b>")],
+  ["tmux bar: dod percent",               () => all.includes("dod <b>25%</b>")],
+  ["palette shortcut label rendered",     () => all.includes("K</kbd>")],
+  ["kanban column progress bars",         () => all.includes('class="kprog"')],
+  ["stat numbers use count-up hooks",     () => all.includes("data-count=")],
+  // segbar cells are <i> elements; done items get className "on" (1 in fixture)
+  ["DoD segmented LED bar: done cell lit", () => cap.includes("CLASS:on")],
+  ["overview prompt line motif",          () => all.includes("prompt-line")],
   // CONTRACT INVARIANT: task ids must be globally unique (the /own:done anchor).
   // This guards the multi-phase mutation case the render-only tests can't reach:
   // Phase 1 and Phase 2 are BOTH specced here, so a phase-local scheme would


### PR DESCRIPTION
## Summary

Promotes the approved v3 design experiment into `core/templates/dashboard.html.template`. The Terminal-Futurism identity (dark, green accent, Outfit + JetBrains Mono, ghost numerals) is preserved — the terminal voice now drives **interaction**, not just decoration.

**The `window.PROJECT` contract is unchanged.** Existing projects upgrade by replacing `dashboard.html` only; `dashboard-data.js` is untouched. (Verified live against a real fully-populated project before promotion.)

### Added
- **Boot sequence** — terminal window types live project status on load; any key skips; `prefers-reduced-motion` bypasses; `#noboot` disables
- **Command palette** — `⌘K`/`Ctrl+K` (platform-aware label) or `/`; digits `1–9` jump views, `[` `]` cycle
- **tmux status bar** — live segments: version, project, phase, tasks, DoD %, ticking clock
- **Mission track** — roadmap as a timeline; progress line interpolates through the active phase's task completion; nodes navigate
- **Task burn** — per-phase progress bars (hollow for roadmap-only phases)
- Micro-interactions: cursor-glow tiles, count-up stats, kanban column progress, segmented LED DoD bar, marching-ants diagram connectors

### Fixed
- **Architecture diagram overflow** — content-aware layout: label gutter sized to longest label, node boxes sized to their text (computable via JetBrains Mono's fixed metrics), proportional scale-down → font shrink → ellipsis with full text as hover tooltip

### Tests
- `dashboard-render.test.js`: 35 → 48 assertions (every v2.5 contract check kept; mission track, burn, tmux, palette, LED bar added)
- `commands.test.sh`: +2 v2.6 template-signature checks
- Full suite: **91/91 across 3 layers** (`bash tests/run.sh`)

### Version
2.5.0 → 2.6.0 (minor: non-empty *Added* section, contract unchanged) across installers, templates, contract, README, CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)